### PR TITLE
Add an initializer that sets value to an initial value

### DIFF
--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -62,6 +62,13 @@ impl Digest {
             value: 0,
         }
     }
+
+    pub fn new_with_value(poly: u32, value: u32) -> Digest {
+        Digest {
+            table: make_table(poly),
+            value: value,
+        }
+    }
 }
 
 impl Hasher32 for Digest {


### PR DESCRIPTION
Some other CRC32 implementations use a starting value other than zero.
Add a method that also initializes digest.value, so we can generate the
same results.