### PR TITLE
Implementation of std::hash::Hasher trait

### DIFF
--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -1,3 +1,5 @@
+use std::hash::Hasher;
+
 pub const CASTAGNOLI: u32 = 0x82f63b78;
 pub const IEEE: u32 = 0xedb88320;
 pub const KOOPMAN: u32 = 0xeb31d82e;
@@ -83,5 +85,16 @@ impl Hasher32 for Digest {
     }
     fn sum32(&self) -> u32 {
         self.value
+    }
+}
+
+/// Implementation of std::hash::Hasher so that types which #[derive(Hash)] can hash with Digest.
+impl Hasher for Digest {
+    fn write(&mut self, bytes: &[u8]) {
+        Hasher32::write(self, bytes);
+    }
+
+    fn finish(&self) -> u64 {
+        self.sum32() as u64
     }
 }

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -1,3 +1,5 @@
+use std::hash::Hasher;
+
 pub const ECMA: u64 = 0xc96c5795d7870f42;
 pub const ISO: u64 = 0xd800000000000000;
 
@@ -77,5 +79,16 @@ impl Hasher64 for Digest {
     }
     fn sum64(&self) -> u64 {
         self.value
+    }
+}
+
+/// Implementation of std::hash::Hasher so that types which #[derive(Hash)] can hash with Digest.
+impl Hasher for Digest {
+    fn write(&mut self, bytes: &[u8]) {
+        Hasher64::write(self, bytes);
+    }
+
+    fn finish(&self) -> u64 {
+        self.sum64()
     }
 }

--- a/tests/hash.rs
+++ b/tests/hash.rs
@@ -1,0 +1,26 @@
+extern crate crc;
+
+mod hasher {
+    use crc::{crc32, crc64};
+    use std::hash::{Hash, Hasher};
+
+    #[derive(Hash)]
+    struct Person(&'static str, u8);
+
+    #[test]
+    fn checksum_hashcrc32() {
+        let person = Person("John Smith", 34);
+        let mut hasher = crc32::Digest::new(crc32::IEEE);
+        person.hash(&mut hasher);
+        assert_eq!(467823795u64, hasher.finish());
+    }
+
+    #[test]
+    fn checksum_hashcrc64() {
+        let person = Person("John Smith", 34);
+        let mut hasher = crc64::Digest::new(crc64::ECMA);
+        person.hash(&mut hasher);
+        assert_eq!(3567258626315136489u64, hasher.finish());
+    }
+
+}


### PR DESCRIPTION
Exports implementations of std::hash::Hasher for crc32::Digest and
crc64::Digest. This allows any types which #[derive(Hash)] to easily
hash using one of the CRC implementations.