### PR TITLE
Use intel crc32 instruction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ license = "MIT"
 
 [dependencies]
 lazy_static = "0.2"
+x86intrin = { version = "0.4.1", optional = true }
+
+[features]
+simd-accel = ["x86intrin"]

--- a/README.md
+++ b/README.md
@@ -69,10 +69,6 @@ digest.write(b"123456789");
 assert_eq!(digest.sum64(), 0x995dc9bbdf1939fa);
 ```
 
-## accelalate by x86intrin
-
-We can use intel crc32 instruction by `RUSTFLAGS="-C target-feature=+sse4.2" cargo build --features=simd-accel`.
-
 ## Benchmark
 
 > Bencher is currently not available in Rust stable releases.
@@ -90,6 +86,58 @@ test bench_crc64_make_table       ... bench:      1200 ns/iter (+/- 223)
 test bench_crc64_update_megabytes ... bench:   2322472 ns/iter (+/- 92870)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured
+```
+
+## accelalate by x86intrin
+
+We can use intel crc32 instruction by `RUSTFLAGS="-C target-feature=+sse4.2" cargo build --features=simd-accel`.
+
+`cargo bench` with 2 GHz Intel Core i7 shows,
+
+```
+$ cargo bench
+   Compiling crc v1.3.0 (file:///Users/hiroki.noda/dev/rust/crc-rs)
+warning: field is never used: `poly`, #[warn(dead_code)] on by default
+  --> src/crc32.rs:17:5
+   |
+17 |     poly: u32
+   |     ^^^^^^^^^
+
+warning: field is never used: `poly`, #[warn(dead_code)] on by default
+  --> src/crc32.rs:17:5
+   |
+17 |     poly: u32
+   |     ^^^^^^^^^
+
+    Finished release [optimized] target(s) in 0.93 secs
+     Running target/release/deps/bench-4ba45ff23227a84d
+
+running 5 tests
+test bench_crc32_castagnoli_update_megabytes ... bench:   2,918,740 ns/iter (+/- 825,319)
+test bench_crc32_ieee_make_table             ... bench:       1,566 ns/iter (+/- 410)
+test bench_crc32_ieee_update_megabytes       ... bench:   2,877,057 ns/iter (+/- 629,496)
+test bench_crc64_make_table                  ... bench:       1,461 ns/iter (+/- 722)
+test bench_crc64_update_megabytes            ... bench:   2,948,650 ns/iter (+/- 701,852)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured
+
+$ RUSTFLAGS="-C target-feature=+sse4.2" cargo bench --features=simd-accel
+   Compiling lazy_static v0.2.2
+   Compiling crc v1.3.0 (file:///Users/hiroki.noda/dev/rust/crc-rs)
+    Finished release [optimized] target(s) in 1.19 secs
+     Running target/release/deps/bench-ea8b558d9102b890
+
+running 5 tests
+test bench_crc32_castagnoli_update_megabytes ... bench:     553,989 ns/iter (+/- 46,970)
+test bench_crc32_ieee_make_table             ... bench:       1,369 ns/iter (+/- 278)
+test bench_crc32_ieee_update_megabytes       ... bench:   2,540,502 ns/iter (+/- 191,396)
+test bench_crc64_make_table                  ... bench:       1,411 ns/iter (+/- 319)
+test bench_crc64_update_megabytes            ... bench:   2,534,612 ns/iter (+/- 134,457)
+     Running target/release/deps/crc-af46900232260aeb
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -7,24 +7,30 @@
 * [Benchmark](#benchmark)
 * [License](#license)
 
-##Usage
+## Usage
+
 Add `crc` to `Cargo.toml`
+
 ```toml
 [dependencies]
 crc = "^1.0.0"
 ```
+
 or
+
 ```toml
 [dependencies.crc]
 git = "https://github.com/mrhooray/crc-rs"
 ```
 
 Add this to crate root
+
 ```rust
 extern crate crc;
 ```
 
 ### Compute CRC32
+
 ```rust
 use crc::{crc32, Hasher32};
 
@@ -45,6 +51,7 @@ assert_eq!(digest.sum32(), 0xcbf43926);
 ```
 
 ### Compute CRC64
+
 ```rust
 use crc::{crc64, Hasher64};
 
@@ -62,10 +69,16 @@ digest.write(b"123456789");
 assert_eq!(digest.sum64(), 0x995dc9bbdf1939fa);
 ```
 
-##Benchmark
+## accelalate by x86intrin
+
+We can use intel crc32 instruction by `RUSTFLAGS="-C target-feature=+sse4.2" cargo build --features=simd-accel`.
+
+## Benchmark
+
 > Bencher is currently not available in Rust stable releases.
 
 `cargo bench` with 2.3 GHz Intel Core i7 results ~430MB/s throughput. [Comparison](http://create.stephan-brumme.com/crc32/)
+
 ```
 cargo bench
      Running target/release/bench-5c82e94dab3e9c79
@@ -79,5 +92,6 @@ test bench_crc64_update_megabytes ... bench:   2322472 ns/iter (+/- 92870)
 test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured
 ```
 
-##License
+## License
+
 MIT

--- a/README.md
+++ b/README.md
@@ -122,17 +122,19 @@ test bench_crc64_update_megabytes            ... bench:   2,948,650 ns/iter (+/-
 test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured
 
 $ RUSTFLAGS="-C target-feature=+sse4.2" cargo bench --features=simd-accel
-   Compiling lazy_static v0.2.2
    Compiling crc v1.3.0 (file:///Users/hiroki.noda/dev/rust/crc-rs)
-    Finished release [optimized] target(s) in 1.19 secs
+    Finished release [optimized] target(s) in 1.1 secs
      Running target/release/deps/bench-ea8b558d9102b890
 
 running 5 tests
-test bench_crc32_castagnoli_update_megabytes ... bench:     553,989 ns/iter (+/- 46,970)
-test bench_crc32_ieee_make_table             ... bench:       1,369 ns/iter (+/- 278)
-test bench_crc32_ieee_update_megabytes       ... bench:   2,540,502 ns/iter (+/- 191,396)
-test bench_crc64_make_table                  ... bench:       1,411 ns/iter (+/- 319)
-test bench_crc64_update_megabytes            ... bench:   2,534,612 ns/iter (+/- 134,457)
+test bench_crc32_castagnoli_update_megabytes ... bench:     431,005 ns/iter (+/- 35,214)
+test bench_crc32_ieee_make_table             ... bench:       1,370 ns/iter (+/- 358)
+test bench_crc32_ieee_update_megabytes       ... bench:   2,529,986 ns/iter (+/- 161,018)
+test bench_crc64_make_table                  ... bench:       1,408 ns/iter (+/- 144)
+test bench_crc64_update_megabytes            ... bench:   2,532,715 ns/iter (+/- 231,801)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured
+
      Running target/release/deps/crc-af46900232260aeb
 
 running 0 tests

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 * [Documentation](http://mrhooray.github.io/crc-rs/crc/index.html)
 * [Usage](#usage)
 * [Benchmark](#benchmark)
+* [accelerate by crc32 intruction](#accelerate by crc32 intruction)
 * [License](#license)
 
 ## Usage
@@ -88,7 +89,7 @@ test bench_crc64_update_megabytes ... bench:   2322472 ns/iter (+/- 92870)
 test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured
 ```
 
-## accelalate by x86intrin
+## accelerate by crc32 intruction
 
 We can use intel crc32 instruction by `RUSTFLAGS="-C target-feature=+sse4.2" cargo build --features=simd-accel`.
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -6,15 +6,21 @@ use crc::{crc32, crc64};
 use test::Bencher;
 
 #[bench]
-fn bench_crc32_make_table(b: &mut Bencher) {
+fn bench_crc32_ieee_make_table(b: &mut Bencher) {
     b.iter(|| crc32::make_table(crc32::IEEE));
 }
 
 #[bench]
-fn bench_crc32_update_megabytes(b: &mut Bencher) {
+fn bench_crc32_ieee_update_megabytes(b: &mut Bencher) {
     let table = crc32::make_table(crc32::IEEE);
     let bytes = Box::new([0u8; 1_000_000]);
     b.iter(|| crc32::update(0, &table, &*bytes));
+}
+
+#[bench]
+fn bench_crc32_castagnoli_update_megabytes(b: &mut Bencher) {
+    let bytes = Box::new([0u8; 1_000_000]);
+    b.iter(|| crc32::checksum_castagnoli(&*bytes));
 }
 
 #[bench]

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -66,9 +66,17 @@ fn update_specialized_sse42(mut value: u32, bytes: &[u8]) -> u32 {
         }
 
         // Process 4 bytes at a time.
+        while i + 8 <= bytes.len() {
+            let v = [  bytes[i], bytes[i+1], bytes[i+2], bytes[i+3],
+                     bytes[i+4], bytes[i+5], bytes[i+6], bytes[i+7]];
+            value = mm_crc32_u64(value as u64, unsafe { mem::transmute::<[u8; 8], u64>(v) }) as u32;
+            i += 8;
+        }
+
+        // Process 4 bytes at a time.
         while i + 4 <= bytes.len() {
             let v = [bytes[i], bytes[i+1], bytes[i+2], bytes[i+3]];
-            value = mm_crc32_u32(value, unsafe { mem::transmute::<[u8; 4], u32>(v) } );
+            value = mm_crc32_u32(value, unsafe { mem::transmute::<[u8; 4], u32>(v) });
             i += 4;
         }
 

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -65,7 +65,7 @@ fn update_specialized_sse42(mut value: u32, bytes: &[u8]) -> u32 {
             value = mm_crc32_u8(value, bytes[e]);
         }
 
-        // Process 4 bytes at a time.
+        // Process 8 bytes at a time.
         while i + 8 <= bytes.len() {
             let v = [  bytes[i], bytes[i+1], bytes[i+2], bytes[i+3],
                      bytes[i+4], bytes[i+5], bytes[i+6], bytes[i+7]];

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -12,7 +12,7 @@ pub struct Digest {
     table: [u32; 256],
     initial: u32,
     value: u32,
-    poly: u32
+    poly: u32,
 }
 
 pub trait Hasher32 {
@@ -61,27 +61,33 @@ fn update_specialized_sse42(mut value: u32, bytes: &[u8]) -> u32 {
         // Process unaligned bytes.
         let p = bytes as *const _;
         let mut i = unsafe { mem::transmute::<*const _, usize>(&p) } % 8;
-        for e in 0 .. i {
+        for e in 0..i {
             value = mm_crc32_u8(value, bytes[e]);
         }
 
         // Process 8 bytes at a time.
         while i + 8 <= bytes.len() {
-            let v = [  bytes[i], bytes[i+1], bytes[i+2], bytes[i+3],
-                     bytes[i+4], bytes[i+5], bytes[i+6], bytes[i+7]];
+            let v = [bytes[i],
+                     bytes[i + 1],
+                     bytes[i + 2],
+                     bytes[i + 3],
+                     bytes[i + 4],
+                     bytes[i + 5],
+                     bytes[i + 6],
+                     bytes[i + 7]];
             value = mm_crc32_u64(value as u64, unsafe { mem::transmute::<[u8; 8], u64>(v) }) as u32;
             i += 8;
         }
 
         // Process 4 bytes at a time.
         while i + 4 <= bytes.len() {
-            let v = [bytes[i], bytes[i+1], bytes[i+2], bytes[i+3]];
+            let v = [bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3]];
             value = mm_crc32_u32(value, unsafe { mem::transmute::<[u8; 4], u32>(v) });
             i += 4;
         }
 
         if bytes.len() - i > 0 {
-            for &e in bytes[i .. ].into_iter() {
+            for &e in bytes[i..].into_iter() {
                 value = mm_crc32_u8(value, e);
             }
         }
@@ -114,7 +120,7 @@ impl Digest {
             table: make_table(poly),
             initial: 0,
             value: 0,
-            poly: poly
+            poly: poly,
         }
     }
 
@@ -123,7 +129,7 @@ impl Digest {
             table: make_table(poly),
             initial: initial,
             value: initial,
-            poly: poly
+            poly: poly,
         }
     }
 }

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -9,7 +9,7 @@ lazy_static! {
 pub struct Digest {
     table: [u64; 256],
     initial: u64,
-    value: u64
+    value: u64,
 }
 
 pub trait Hasher64 {
@@ -55,7 +55,7 @@ impl Digest {
         Digest {
             table: make_table(poly),
             initial: 0,
-            value: 0
+            value: 0,
         }
     }
 
@@ -63,7 +63,7 @@ impl Digest {
         Digest {
             table: make_table(poly),
             initial: initial,
-            value: initial
+            value: initial,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,13 @@
 //! digest.write(b"123456789");
 //! assert_eq!(digest.sum64(), 0x995dc9bbdf1939fa);
 //! ```
+#![cfg_attr(feature = "simd-accel", feature(cfg_target_feature))]
 
 #[macro_use]
 extern crate lazy_static;
+
+#[cfg(feature = "simd-accel")]
+extern crate x86intrin;
 
 pub mod crc32;
 pub mod crc64;

--- a/tests/crc.rs
+++ b/tests/crc.rs
@@ -4,12 +4,18 @@ mod crc32 {
     use crc::{crc32, Hasher32};
 
     const CASTAGNOLI_CHECK_VALUE: u32 = 0xe3069283;
+    const LONG_CASTAGNOLI_CHECK_VALUE: u32 = 0x7f269791;
     const IEEE_CHECK_VALUE: u32 = 0xcbf43926;
     const KOOPMAN_CHECK_VALUE: u32 = 0x2d3dd0ae;
 
     #[test]
     fn checksum_castagnoli() {
         assert_eq!(crc32::checksum_castagnoli(b"123456789"), CASTAGNOLI_CHECK_VALUE)
+    }
+
+    #[test]
+    fn checksum_castagnoli_long_bytes() {
+        assert_eq!(crc32::checksum_castagnoli(b"1234567890ABCDEF"), LONG_CASTAGNOLI_CHECK_VALUE)
     }
 
     #[test]

--- a/tests/crc.rs
+++ b/tests/crc.rs
@@ -10,12 +10,14 @@ mod crc32 {
 
     #[test]
     fn checksum_castagnoli() {
-        assert_eq!(crc32::checksum_castagnoli(b"123456789"), CASTAGNOLI_CHECK_VALUE)
+        assert_eq!(crc32::checksum_castagnoli(b"123456789"),
+                   CASTAGNOLI_CHECK_VALUE)
     }
 
     #[test]
     fn checksum_castagnoli_long_bytes() {
-        assert_eq!(crc32::checksum_castagnoli(b"1234567890ABCDEF"), LONG_CASTAGNOLI_CHECK_VALUE)
+        assert_eq!(crc32::checksum_castagnoli(b"1234567890ABCDEF"),
+                   LONG_CASTAGNOLI_CHECK_VALUE)
     }
 
     #[test]


### PR DESCRIPTION
Use intel crc32 instruction (SSE4.2) via x86intrin crate when `RUSTFLAGS="-C target-feature=+sse4.2" cargo build --features=simd-accel`.