### PR TITLE
add no_std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ license = "MIT"
 
 [dependencies]
 lazy_static = "0.2"
+
+[features]
+no_std = ["lazy_static/spin_no_std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,14 @@ documentation = "http://mrhooray.github.io/crc-rs/crc/index.html"
 license = "MIT"
 
 [dependencies]
-lazy_static = "0.2"
+
+[dependencies.build_const]
+version = "0.2"
+default-features = false
+
+[build-dependencies]
+build_const = "0.2"
 
 [features]
-no_std = ["lazy_static/spin_no_std"]
+std = []
+default = ["std"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,73 @@
+
+extern crate build_const;
+
+pub fn make_table_crc32(poly: u32) -> [u32; 256] {
+    let mut table = [0u32; 256];
+    for i in 0..256 {
+        let mut value = i as u32;
+        for _ in 0..8 {
+            value = if (value & 1) == 1 {
+                (value >> 1) ^ poly
+            } else {
+                value >> 1
+            }
+        }
+        table[i] = value;
+    }
+    table
+}
+
+pub fn make_table_crc64(poly: u64) -> [u64; 256] {
+    let mut table = [0u64; 256];
+    for i in 0..256 {
+        let mut value = i as u64;
+        for _ in 0..8 {
+            value = if (value & 1) == 1 {
+                (value >> 1) ^ poly
+            } else {
+                value >> 1
+            }
+        }
+        table[i] = value;
+    }
+    table
+}
+
+#[allow(non_snake_case)]
+fn create_constants() {
+    let mut crc32 = build_const::ConstWriter::for_build("crc32_constants")
+        .unwrap()
+        .finish_dependencies();
+    let CASTAGNOLI: u32 = 0x82f63b78;
+    crc32.add_value("CASTAGNOLI", "u32", CASTAGNOLI);
+    crc32.add_array("CASTAGNOLI_TABLE", "u32", &make_table_crc32(CASTAGNOLI));
+
+    let IEEE: u32 = 0xedb88320;
+    crc32.add_value("IEEE", "u32", IEEE);
+    crc32.add_array("IEEE_TABLE", "u32", &make_table_crc32(IEEE));
+
+    let KOOPMAN: u32 = 0xeb31d82e;
+    crc32.add_value("KOOPMAN", "u32", KOOPMAN);
+    crc32.add_array("KOOPMAN_TABLE", "u32", &make_table_crc32(KOOPMAN));
+
+    crc32.finish();
+
+    let mut crc64 = build_const::ConstWriter::for_build("crc64_constants")
+        .unwrap()
+        .finish_dependencies();
+
+    let ECMA: u64 = 0xc96c5795d7870f42;
+    crc64.add_value("ECMA", "u64", ECMA);
+    crc64.add_array("ECMA_TABLE", "u64", &make_table_crc64(ECMA));
+
+    let ISO: u64 = 0xd800000000000000;
+    crc64.add_value("ISO", "u64", ISO);
+    crc64.add_array("ISO_TABLE", "u64", &make_table_crc64(ISO));
+
+    crc64.finish();
+}
+
+fn main() {
+    create_constants();
+}
+

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "no_std")]
+use core::hash::Hasher;
+#[cfg(not(feature = "no_std"))]
 use std::hash::Hasher;
 
 pub const CASTAGNOLI: u32 = 0x82f63b78;

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -1,17 +1,19 @@
-#[cfg(feature = "no_std")]
-use core::hash::Hasher;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::hash::Hasher;
+#[cfg(not(feature = "std"))]
+use core::hash::Hasher;
 
-pub const CASTAGNOLI: u32 = 0x82f63b78;
-pub const IEEE: u32 = 0xedb88320;
-pub const KOOPMAN: u32 = 0xeb31d82e;
+//pub const CASTAGNOLI: u32 = 0x82f63b78;
+//pub const IEEE: u32 = 0xedb88320;
+//pub const KOOPMAN: u32 = 0xeb31d82e;
 
-lazy_static! {
-    pub static ref IEEE_TABLE: [u32; 256] = make_table(IEEE);
-    pub static ref CASTAGNOLI_TABLE: [u32; 256] = make_table(CASTAGNOLI);
-    pub static ref KOOPMAN_TABLE: [u32; 256] = make_table(KOOPMAN);
-}
+//lazy_static! {
+//    pub static ref IEEE_TABLE: [u32; 256] = make_table(IEEE);
+//    pub static ref CASTAGNOLI_TABLE: [u32; 256] = make_table(CASTAGNOLI);
+//    pub static ref KOOPMAN_TABLE: [u32; 256] = make_table(KOOPMAN);
+//}
+
+build_const!("crc32_constants");
 
 pub struct Digest {
     table: [u32; 256],

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -3,16 +3,6 @@ use std::hash::Hasher;
 #[cfg(not(feature = "std"))]
 use core::hash::Hasher;
 
-//pub const CASTAGNOLI: u32 = 0x82f63b78;
-//pub const IEEE: u32 = 0xedb88320;
-//pub const KOOPMAN: u32 = 0xeb31d82e;
-
-//lazy_static! {
-//    pub static ref IEEE_TABLE: [u32; 256] = make_table(IEEE);
-//    pub static ref CASTAGNOLI_TABLE: [u32; 256] = make_table(CASTAGNOLI);
-//    pub static ref KOOPMAN_TABLE: [u32; 256] = make_table(KOOPMAN);
-//}
-
 build_const!("crc32_constants");
 
 pub struct Digest {

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -1,15 +1,17 @@
-#[cfg(feature = "no_std")]
-use core::hash::Hasher;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::hash::Hasher;
+#[cfg(not(feature = "std"))]
+use core::hash::Hasher;
 
-pub const ECMA: u64 = 0xc96c5795d7870f42;
-pub const ISO: u64 = 0xd800000000000000;
+//pub const ECMA: u64 = 0xc96c5795d7870f42;
+//pub const ISO: u64 = 0xd800000000000000;
 
-lazy_static! {
-    pub static ref ECMA_TABLE: [u64; 256] = make_table(ECMA);
-    pub static ref ISO_TABLE: [u64; 256] = make_table(ISO);
-}
+//lazy_static! {
+//    pub static ref ECMA_TABLE: [u64; 256] = make_table(ECMA);
+//    pub static ref ISO_TABLE: [u64; 256] = make_table(ISO);
+//}
+
+build_const!("crc64_constants");
 
 pub struct Digest {
     table: [u64; 256],

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -3,14 +3,6 @@ use std::hash::Hasher;
 #[cfg(not(feature = "std"))]
 use core::hash::Hasher;
 
-//pub const ECMA: u64 = 0xc96c5795d7870f42;
-//pub const ISO: u64 = 0xd800000000000000;
-
-//lazy_static! {
-//    pub static ref ECMA_TABLE: [u64; 256] = make_table(ECMA);
-//    pub static ref ISO_TABLE: [u64; 256] = make_table(ISO);
-//}
-
 build_const!("crc64_constants");
 
 pub struct Digest {

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "no_std")]
+use core::hash::Hasher;
+#[cfg(not(feature = "no_std"))]
 use std::hash::Hasher;
 
 pub const ECMA: u64 = 0xc96c5795d7870f42;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,10 +40,10 @@
 //! assert_eq!(digest.sum64(), 0x995dc9bbdf1939fa);
 //! ```
 
-#![cfg_attr(feature = "no_std", no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]
-extern crate lazy_static;
+extern crate build_const;
 
 pub mod crc32;
 pub mod crc64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@
 //! assert_eq!(digest.sum64(), 0x995dc9bbdf1939fa);
 //! ```
 
+#![cfg_attr(feature = "no_std", no_std)]
+
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
this adds support for `no_std` applications/libraries (like microcontrollers) by using conditional features

- rust-lang/cargo#633

On nightly with no_std:
```
#  rustup run nightly cargo test --features no_std                                                                                                                                           <<<
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running target/debug/deps/crc-c3e90d0dfab413be

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured

     Running target/debug/deps/crc-9d7b680262789a74

running 10 tests
test crc32::checksum_castagnoli ... ok
test crc32::checksum_ieee ... ok
test crc32::digest_castagnoli ... ok
test crc32::checksum_koopman ... ok
test crc32::digest_ieee ... ok
test crc64::checksum_ecma ... ok
test crc32::digest_koopman ... ok
test crc64::digest_iso ... ok
test crc64::checksum_iso ... ok
test crc64::digest_ecma ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured

     Running target/debug/deps/hash-bb44b103cb920ad0

running 2 tests
test hasher::checksum_hashcrc32 ... ok
test hasher::checksum_hashcrc64 ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured

   Doc-tests crc

running 2 tests
test src/lib.rs -  (line 6) ... ok
test src/lib.rs -  (line 27) ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured
```
on stable with std:
```
# rustup run stable cargo test                                                                                                                                                                 
   Compiling crc v1.4.0 (file:///home/garrett/projects/ruststuff/crc-rs)                                                                                                                                          
    Finished dev [unoptimized + debuginfo] target(s) in 1.64 secs                                                                                                                                                 
     Running target/debug/deps/crc-57a43f894e443797                                                                                                                                                               
                                                                                                                                                                                                                  
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured

     Running target/debug/deps/crc-79b2fcd023832a0c                                                                                                                                                               
                                                                                                                                                                                                                  
running 10 tests
test crc32::checksum_castagnoli ... ok                                                                                                                                                                            
test crc32::checksum_ieee ... ok                                                                                                                                                                                  
test crc32::checksum_koopman ... ok                                                                                                                                                                               
test crc32::digest_castagnoli ... ok                                                                                                                                                                              
test crc32::digest_ieee ... ok                                                                                                                                                                                    
test crc64::checksum_iso ... ok                                                                                                                                                                                   
test crc64::checksum_ecma ... ok                                                                                                                                                                                  
test crc64::digest_ecma ... ok                                                                                                                                                                                    
test crc32::digest_koopman ... ok                                                                                                                                                                                 
test crc64::digest_iso ... ok                                                                                                                                                                                     
                                                                                                                                                                                                                  
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured

     Running target/debug/deps/hash-da1e5eadb26ad3bb                                                                                                                                                              
                                                                                                                                                                                                                  
running 2 tests
test hasher::checksum_hashcrc32 ... ok
test hasher::checksum_hashcrc64 ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured

   Doc-tests crc                                                                                                                                                                                                  
                                                                                                                                                                                                                  
running 2 tests
test src/lib.rs -  (line 27) ... ok                                                                                                                                                                               
test src/lib.rs -  (line 6) ... ok                                                                                                                                                                                
                                                                                                                                                                                                                  
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured
#

