### PR TITLE
add support for linux kernel compatible crc32

### DIFF
--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -39,6 +39,10 @@ pub fn checksum_koopman(bytes: &[u8]) -> u32 {
     return update(0, &KOOPMAN_TABLE, bytes);
 }
 
+pub fn checksum_linux(bytes: &[u8]) -> u32 {
+    return ! update(1, &CASTAGNOLI_TABLE, bytes);
+}
+
 impl Digest {
     pub fn new(poly: u32) -> Digest {
         Digest {

--- a/tests/crc.rs
+++ b/tests/crc.rs
@@ -6,6 +6,7 @@ mod crc32 {
     const CASTAGNOLI_CHECK_VALUE: u32 = 0xe3069283;
     const IEEE_CHECK_VALUE: u32 = 0xcbf43926;
     const KOOPMAN_CHECK_VALUE: u32 = 0x2d3dd0ae;
+    const LINUX_CHECK_VALUE: u32 = 0xe8c7bb34;
 
     #[test]
     fn checksum_castagnoli() {
@@ -20,6 +21,11 @@ mod crc32 {
     #[test]
     fn checksum_koopman() {
         assert_eq!(crc32::checksum_koopman(b"123456789"), KOOPMAN_CHECK_VALUE)
+    }
+
+    #[test]
+    pub fn checksum_linux () {
+        assert_eq! (crc32::checksum_linux (b"123456789"), LINUX_CHECK_VALUE)
     }
 
     #[test]


### PR DESCRIPTION
The linux kernel uses a slightly different version of CRC32-C. The seed value is "~ 1", or 0xFFFFFFFE, and the result is not bitwise inverted. The polynomial is the same as normal.

This adds a `crc32::checksum_linux` function which generates these checksums.