### PR TITLE
Avoid a direct dependency on build_const

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,6 @@ readme = "README.md"
 repository = "https://github.com/mrhooray/crc-rs.git"
 license = "MIT OR Apache-2.0"
 
-[dependencies]
-build_const = { version = "0.2", default-features = false }
-
 [build-dependencies]
 build_const = "0.2"
 

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -5,7 +5,7 @@ use core::hash::Hasher;
 
 pub use util::make_table_crc32 as make_table;
 
-build_const!("crc32_constants");
+include!(concat!(env!("OUT_DIR"), "/crc32_constants.rs"));
 
 pub struct Digest {
     table: [u32; 256],

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -5,7 +5,7 @@ use core::hash::Hasher;
 
 pub use util::make_table_crc64 as make_table;
 
-build_const!("crc64_constants");
+include!(concat!(env!("OUT_DIR"), "/crc64_constants.rs"));
 
 pub struct Digest {
     table: [u64; 256],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[macro_use]
-extern crate build_const;
-
 pub mod crc32;
 pub mod crc64;
 mod util;


### PR DESCRIPTION
See rust-lang/cargo#4866 for explanation.