### PR TITLE
Rust edition 2018, `no_std` default, README and CI changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,14 @@
 language: rust
 rust:
-    - nightly
-    - stable
+  - stable
+  - beta
+  - nightly
+  - 1.32.0
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
+  include:
+    - rust: stable
+      script: 'cargo bench'
+cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,21 @@
 [package]
 name = "crc"
-version = "1.8.1"
+version = "2.0.0"
 authors = ["Rui Hu <code@mrhooray.com>"]
-description = "Rust implementation of CRC(16, 32, 64) with support of various standards"
-keywords = ["crc", "crc16", "crc32", "crc64", "hash"]
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/mrhooray/crc-rs.git"
 documentation = "https://docs.rs/crc"
-license = "MIT OR Apache-2.0"
+description = "Rust implementation of CRC(16, 32, 64) with support of various standards"
+keywords = ["crc", "crc16", "crc32", "crc64", "hash"]
+categories = ["algorithms", "no-std"]
+edition = "2018"
 
 [build-dependencies]
 build_const = "0.2"
 
-[features]
-std = []
-default = ["std"]
-
 [dev-dependencies]
-criterion = "0.2.5"
+criterion = "0.3"
 
 [[bench]]
 name = "bench"

--- a/README.md
+++ b/README.md
@@ -1,27 +1,17 @@
-# crc [![Build Status](https://travis-ci.org/mrhooray/crc-rs.svg?branch=master)](https://travis-ci.org/mrhooray/crc-rs)
-> Rust implementation of CRC(16, 32, 64) with support of various standards
+# crc
 
-* [Crate](https://crates.io/crates/crc)
-* [Documentation](https://docs.rs/crc/)
-* [Usage](#usage)
-* [Benchmark](#benchmark)
-* [License](#license)
+[![Build Status](https://travis-ci.org/mrhooray/crc-rs.svg?branch=master)](https://travis-ci.org/mrhooray/crc-rs)
+[![Crate](https://img.shields.io/crates/v/crc.svg)](https://crates.io/crates/crc)
+[![Docs](https://docs.rs/crc/badge.svg)](https://docs.rs/crc)
+[![License](https://img.shields.io/crates/l/crc.svg?maxAge=2592000)](https://github.com/mrhooray/crc-rs#license)
+
+Rust implementation of CRC(16, 32, 64) with support of various standards
 
 ## Usage
 Add `crc` to `Cargo.toml`
 ```toml
 [dependencies]
-crc = "^1.0.0"
-```
-or
-```toml
-[dependencies.crc]
-git = "https://github.com/mrhooray/crc-rs"
-```
-
-Add this to crate root
-```rust
-extern crate crc;
+crc = "2.0"
 ```
 
 ### Compute CRC16
@@ -42,7 +32,7 @@ digest.write(b"123456789");
 assert_eq!(digest.sum16(), 0x906e);
 
 // more customization
-let mut digest = crc16::Digest::new_custom(crc16::X25, !0u16, !0u16, crc::CalcType::Reverse);
+let mut digest = crc16::Digest::new_custom(crc16::X25, 0u16, 0u16, crc::CalcType::Reverse);
 digest.write(b"123456789");
 assert_eq!(digest.sum16(), 0x906e);
 ```
@@ -67,7 +57,7 @@ digest.write(b"123456789");
 assert_eq!(digest.sum32(), 0xcbf43926);
 
 // more customization
-let mut digest = crc32::Digest::new_custom(crc32::IEEE, !0u32, !0u32, crc::CalcType::Reverse);
+let mut digest = crc32::Digest::new_custom(crc32::IEEE, 0u32, 0u32, crc::CalcType::Reverse);
 digest.write(b"123456789");
 assert_eq!(digest.sum32(), 0xcbf43926);
 ```
@@ -90,13 +80,12 @@ digest.write(b"123456789");
 assert_eq!(digest.sum64(), 0x995dc9bbdf1939fa);
 
 // more customization
-let mut digest = crc64::Digest::new_custom(crc64::ECMA, !0u64, !0u64, crc::CalcType::Reverse);
+let mut digest = crc64::Digest::new_custom(crc64::ECMA, 0u64, 0u64, crc::CalcType::Reverse);
 digest.write(b"123456789");
 assert_eq!(digest.sum64(), 0x995dc9bbdf1939fa);
 ```
 
 ## Benchmark
-> Bencher is currently not available in Rust stable releases.
 
 `cargo bench` with 2.3 GHz Intel Core i7 results ~430MB/s throughput. [Comparison](http://create.stephan-brumme.com/crc32/)
 ```

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,8 +1,5 @@
-extern crate crc;
-#[macro_use]
-extern crate criterion;
-
 use crc::{crc16, crc32, crc64};
+use criterion::{criterion_group, criterion_main};
 use criterion::{Benchmark, Criterion, Throughput};
 
 fn crc16_make_table(c: &mut Criterion) {

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -1,10 +1,7 @@
-#[cfg(not(feature = "std"))]
 use core::hash::Hasher;
-#[cfg(feature = "std")]
-use std::hash::Hasher;
 
-use super::CalcType;
-pub use util::make_table_crc16 as make_table;
+use crate::CalcType;
+pub use crate::util::make_table_crc16 as make_table;
 
 include!(concat!(env!("OUT_DIR"), "/crc16_constants.rs"));
 

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -1,10 +1,7 @@
-#[cfg(not(feature = "std"))]
 use core::hash::Hasher;
-#[cfg(feature = "std")]
-use std::hash::Hasher;
 
-use super::CalcType;
-pub use util::make_table_crc32 as make_table;
+use crate::CalcType;
+pub use crate::util::make_table_crc32 as make_table;
 
 include!(concat!(env!("OUT_DIR"), "/crc32_constants.rs"));
 

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -1,10 +1,7 @@
-#[cfg(not(feature = "std"))]
 use core::hash::Hasher;
-#[cfg(feature = "std")]
-use std::hash::Hasher;
 
-use super::CalcType;
-pub use util::make_table_crc64 as make_table;
+use crate::CalcType;
+pub use crate::util::make_table_crc64 as make_table;
 
 include!(concat!(env!("OUT_DIR"), "/crc64_constants.rs"));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //! digest.write(b"123456789");
 //! assert_eq!(digest.sum64(), 0x995dc9bbdf1939fa);
 //! ```
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 pub mod crc16;
 pub mod crc32;


### PR DESCRIPTION
- `extern crate ...;` is deprecated.
- Cargo features should be used for "additive" functionality. So, it makes sense to remove the `std` feature.
- Modifying features requires version bump since it could be a breaking change.
