### PR TITLE
Address clippy lint warnings.

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -18,7 +18,8 @@ fn crc16_update_megabytes(c: &mut Criterion) {
         "crc16_update_megabytes",
         Benchmark::new("crc16_update_megabytes", move |b| {
             b.iter(|| crc16::update(0, &table, &*bytes, &crc::CalcType::Reverse))
-        }).throughput(Throughput::Bytes(1_000_000)),
+        })
+        .throughput(Throughput::Bytes(1_000_000)),
     );
 }
 
@@ -35,7 +36,8 @@ fn crc32_update_megabytes(c: &mut Criterion) {
         "crc32_update_megabytes",
         Benchmark::new("crc32_update_megabytes", move |b| {
             b.iter(|| crc32::update(0, &table, &*bytes, &crc::CalcType::Reverse))
-        }).throughput(Throughput::Bytes(1_000_000)),
+        })
+        .throughput(Throughput::Bytes(1_000_000)),
     );
 }
 
@@ -52,7 +54,8 @@ fn crc64_update_megabytes(c: &mut Criterion) {
         "crc64_update_megabytes",
         Benchmark::new("crc64_update_megabytes", move |b| {
             b.iter(|| crc64::update(0, &table, &*bytes, &crc::CalcType::Reverse))
-        }).throughput(Throughput::Bytes(1_000_000)),
+        })
+        .throughput(Throughput::Bytes(1_000_000)),
     );
 }
 

--- a/build.rs
+++ b/build.rs
@@ -2,17 +2,24 @@ extern crate build_const;
 
 include!("src/util.rs");
 
+const ALLOW_UNREADABLE_LITERAL_LINT: &str = "#[allow(clippy::unreadable_literal)]";
+
 #[allow(non_snake_case)]
 fn create_constants() {
     let mut crc16 = build_const::ConstWriter::for_build("crc16_constants")
         .unwrap()
         .finish_dependencies();
+
     let X25: u16 = 0x1021;
+    crc16.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc16.add_value("X25", "u16", X25);
+    crc16.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc16.add_array("X25_TABLE", "u16", &make_table_crc16(X25, true));
 
     let USB: u16 = 0x8005;
+    crc16.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc16.add_value("USB", "u16", USB);
+    crc16.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc16.add_array("USB_TABLE", "u16", &make_table_crc16(USB, true));
 
     crc16.finish();
@@ -20,20 +27,27 @@ fn create_constants() {
     let mut crc32 = build_const::ConstWriter::for_build("crc32_constants")
         .unwrap()
         .finish_dependencies();
-    let CASTAGNOLI: u32 = 0x1EDC6F41;
+
+    let CASTAGNOLI: u32 = 0x1EDC_6F41;
+    crc32.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc32.add_value("CASTAGNOLI", "u32", CASTAGNOLI);
+    crc32.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc32.add_array(
         "CASTAGNOLI_TABLE",
         "u32",
         &make_table_crc32(CASTAGNOLI, true),
     );
 
-    let IEEE: u32 = 0x04C11DB7;
+    let IEEE: u32 = 0x04C1_1DB7;
+    crc32.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc32.add_value("IEEE", "u32", IEEE);
+    crc32.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc32.add_array("IEEE_TABLE", "u32", &make_table_crc32(IEEE, true));
 
-    let KOOPMAN: u32 = 0x741B8CD7;
+    let KOOPMAN: u32 = 0x741B_8CD7;
+    crc32.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc32.add_value("KOOPMAN", "u32", KOOPMAN);
+    crc32.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc32.add_array("KOOPMAN_TABLE", "u32", &make_table_crc32(KOOPMAN, true));
 
     crc32.finish();
@@ -42,12 +56,16 @@ fn create_constants() {
         .unwrap()
         .finish_dependencies();
 
-    let ECMA: u64 = 0x42F0E1EBA9EA3693;
+    let ECMA: u64 = 0x42F0_E1EB_A9EA_3693;
+    crc64.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc64.add_value("ECMA", "u64", ECMA);
+    crc64.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc64.add_array("ECMA_TABLE", "u64", &make_table_crc64(ECMA, true));
 
-    let ISO: u64 = 0x000000000000001B;
+    let ISO: u64 = 0x0000_0000_0000_001B;
+    crc64.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc64.add_value("ISO", "u64", ISO);
+    crc64.add_raw(ALLOW_UNREADABLE_LITERAL_LINT);
     crc64.add_array("ISO_TABLE", "u64", &make_table_crc64(ISO, true));
 
     crc64.finish();

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -58,12 +58,12 @@ pub fn update(mut value: u16, table: &[u16; 256], bytes: &[u8], calc: &CalcType)
 
 /// Generates a X25 16 bit CRC checksum (AKA CRC-16-CCITT).
 pub fn checksum_x25(bytes: &[u8]) -> u16 {
-    return update(0u16, &X25_TABLE, bytes, &CalcType::Compat);
+    update(0u16, &X25_TABLE, bytes, &CalcType::Compat)
 }
 
 /// Generates a USB 16 bit CRC checksum (AKA CRC-16-IBM).
 pub fn checksum_usb(bytes: &[u8]) -> u16 {
-    return update(0u16, &USB_TABLE, bytes, &CalcType::Compat);
+    update(0u16, &USB_TABLE, bytes, &CalcType::Compat)
 }
 
 impl Digest {
@@ -149,7 +149,7 @@ impl Hasher16 for Digest {
 
 impl Hasher for Digest {
     fn finish(&self) -> u64 {
-        self.sum16() as u64
+        u64::from(self.sum16())
     }
 
     fn write(&mut self, bytes: &[u8]) {

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -58,17 +58,17 @@ pub fn update(mut value: u32, table: &[u32; 256], bytes: &[u8], calc: &CalcType)
 
 /// Generates a IEEE 32 bit CRC checksum (AKA CRC32).
 pub fn checksum_ieee(bytes: &[u8]) -> u32 {
-    return update(0u32, &IEEE_TABLE, bytes, &CalcType::Compat);
+    update(0u32, &IEEE_TABLE, bytes, &CalcType::Compat)
 }
 
 /// Generates a Castagnoli 32 bit CRC checksum (AKA CRC32-C).
 pub fn checksum_castagnoli(bytes: &[u8]) -> u32 {
-    return update(0u32, &CASTAGNOLI_TABLE, bytes, &CalcType::Compat);
+    update(0u32, &CASTAGNOLI_TABLE, bytes, &CalcType::Compat)
 }
 
 /// Generates a Koopman 32 bit CRC checksum (AKA CRC32-K).
 pub fn checksum_koopman(bytes: &[u8]) -> u32 {
-    return update(0u32, &KOOPMAN_TABLE, bytes, &CalcType::Compat);
+    update(0u32, &KOOPMAN_TABLE, bytes, &CalcType::Compat)
 }
 
 impl Digest {
@@ -154,7 +154,7 @@ impl Hasher32 for Digest {
 
 impl Hasher for Digest {
     fn finish(&self) -> u64 {
-        self.sum32() as u64
+        u64::from(self.sum32())
     }
 
     fn write(&mut self, bytes: &[u8]) {

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -58,12 +58,12 @@ pub fn update(mut value: u64, table: &[u64; 256], bytes: &[u8], calc: &CalcType)
 
 /// Generates a ECMA-188 64 bit CRC checksum (AKA CRC-64-ECMA).
 pub fn checksum_ecma(bytes: &[u8]) -> u64 {
-    return update(0u64, &ECMA_TABLE, bytes, &CalcType::Compat);
+    update(0u64, &ECMA_TABLE, bytes, &CalcType::Compat)
 }
 
 /// Generates a ISO 3309 32 bit CRC checksum (AKA CRC-64-ISO).
 pub fn checksum_iso(bytes: &[u8]) -> u64 {
-    return update(0u64, &ISO_TABLE, bytes, &CalcType::Compat);
+    update(0u64, &ISO_TABLE, bytes, &CalcType::Compat)
 }
 
 impl Digest {
@@ -149,7 +149,7 @@ impl Hasher64 for Digest {
 
 impl Hasher for Digest {
     fn finish(&self) -> u64 {
-        self.sum64() as u64
+        self.sum64()
     }
 
     fn write(&mut self, bytes: &[u8]) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@
 //! assert_eq!(digest.sum64(), 0x995dc9bbdf1939fa);
 //! ```
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::unreadable_literal)]
 
 pub mod crc16;
 pub mod crc32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,6 @@
 //! assert_eq!(digest.sum64(), 0x995dc9bbdf1939fa);
 //! ```
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(clippy::unreadable_literal)]
 
 pub mod crc16;
 pub mod crc32;

--- a/src/util.rs
+++ b/src/util.rs
@@ -112,7 +112,7 @@ fn reflect_value_16(mut value: u16) -> u16 {
         if (value & 0x01) == 1 {
             reflection |= 1 << ((bits - 1) - i)
         }
-        value = value >> 1;
+        value >>= 1;
     }
     reflection
 }
@@ -126,7 +126,7 @@ fn reflect_value_32(mut value: u32) -> u32 {
         if (value & 0x01) == 1 {
             reflection |= 1 << ((bits - 1) - i)
         }
-        value = value >> 1;
+        value >>= 1;
     }
     reflection
 }
@@ -140,7 +140,7 @@ fn reflect_value_64(mut value: u64) -> u64 {
         if (value & 0x01) == 1 {
             reflection |= 1 << ((bits - 1) - i)
         }
-        value = value >> 1;
+        value >>= 1;
     }
     reflection
 }
@@ -155,7 +155,7 @@ fn reflect_byte_16(input: u16) -> u16 {
         if (value & 0x01) == 1 {
             reflection |= 1 << ((bits - 1) - i)
         }
-        value = value >> 1;
+        value >>= 1;
     }
     reflection
 }
@@ -170,7 +170,7 @@ fn reflect_byte_32(input: u32) -> u32 {
         if (value & 0x01) == 1 {
             reflection |= 1 << ((bits - 1) - i)
         }
-        value = value >> 1;
+        value >>= 1;
     }
     reflection
 }
@@ -185,7 +185,7 @@ fn reflect_byte_64(input: u64) -> u64 {
         if (value & 0x01) == 1 {
             reflection |= 1 << ((bits - 1) - i)
         }
-        value = value >> 1;
+        value >>= 1;
     }
     reflection
 }

--- a/tests/crc.rs
+++ b/tests/crc.rs
@@ -41,9 +41,9 @@ mod crc16 {
 mod crc32 {
     use crc::{crc32, Hasher32};
 
-    const CASTAGNOLI_CHECK_VALUE: u32 = 0xe3069283;
-    const IEEE_CHECK_VALUE: u32 = 0xcbf43926;
-    const KOOPMAN_CHECK_VALUE: u32 = 0x2d3dd0ae;
+    const CASTAGNOLI_CHECK_VALUE: u32 = 0xe306_9283;
+    const IEEE_CHECK_VALUE: u32 = 0xcbf4_3926;
+    const KOOPMAN_CHECK_VALUE: u32 = 0x2d3d_d0ae;
 
     #[test]
     fn checksum_castagnoli() {
@@ -93,8 +93,8 @@ mod crc32 {
 mod crc64 {
     use crc::{crc64, CalcType, Hasher64};
 
-    const ECMA_CHECK_VALUE: u64 = 0x995dc9bbdf1939fa;
-    const ISO_CHECK_VALUE: u64 = 0xb90956c775a41001;
+    const ECMA_CHECK_VALUE: u64 = 0x995d_c9bb_df19_39fa;
+    const ISO_CHECK_VALUE: u64 = 0xb909_56c7_75a4_1001;
 
     #[test]
     fn checksum_ecma() {

--- a/tests/hasher.rs
+++ b/tests/hasher.rs
@@ -12,7 +12,7 @@ mod hasher {
         let person = Person("John Smith", 34);
         let mut hasher = crc16::Digest::new(crc16::X25);
         person.hash(&mut hasher);
-        assert_eq!(27228u64, hasher.finish());
+        assert_eq!(27_228u64, hasher.finish());
     }
 
     #[test]
@@ -20,7 +20,7 @@ mod hasher {
         let person = Person("John Smith", 34);
         let mut hasher = crc32::Digest::new(crc32::IEEE);
         person.hash(&mut hasher);
-        assert_eq!(467823795u64, hasher.finish());
+        assert_eq!(467_823_795u64, hasher.finish());
     }
 
     #[test]
@@ -28,7 +28,7 @@ mod hasher {
         let person = Person("John Smith", 34);
         let mut hasher = crc64::Digest::new(crc64::ECMA);
         person.hash(&mut hasher);
-        assert_eq!(3567258626315136489u64, hasher.finish());
+        assert_eq!(3_567_258_626_315_136_489u64, hasher.finish());
     }
 
 }


### PR DESCRIPTION
This pull request updates the code base so that all Clippy lint warnings are resolved, with the exception of the unreadable_literal warning in auto-generated tables. I am unaware of a way to make the code generator format the literals properly. However, as the unreadable_literal lint is just for stylistic purposes, ignoring it has no impact on the functionality or performance of the crate.

All non-benchmark tests have been run and are passing. Additionally, the code has been formatted with  rustfmt.
