### PR TITLE
Generalize CRC table generator logic into macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,10 +74,11 @@
 //! ```
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[macro_use]
+mod util;
 pub mod crc16;
 pub mod crc32;
 pub mod crc64;
-mod util;
 
 pub use self::crc16::Hasher16;
 pub use self::crc32::Hasher32;

--- a/src/util.rs
+++ b/src/util.rs
@@ -30,6 +30,8 @@ macro_rules! reflect_value {
     }};
 }
 
+/// Builds a CRC table from the given polynomial, applying input reflection and output reflection
+/// as specified.
 macro_rules! make_table {
     ($polynomial:expr, $reflect_in:expr, $reflect_out:expr) => {{
         let mut table = [0; 256];

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,191 +1,86 @@
+#[doc(hidden)]
+macro_rules! reflect {
+    ($bits:expr, $value:expr) => {{
+        let mut reflection = 0;
+        let mut value = $value;
+
+        for i in 0..$bits {
+            if (value & 0x01) == 1 {
+                reflection |= 1 << (($bits - 1) - i)
+            }
+
+            value >>= 1;
+        }
+
+        reflection
+    }};
+}
+
+#[doc(hidden)]
+macro_rules! reflect_byte {
+    ($value:expr) => {{
+        reflect!(8, $value)
+    }};
+}
+
+#[doc(hidden)]
+macro_rules! reflect_value {
+    ($value:expr) => {{
+        reflect!(core::mem::size_of_val(&$value) * 8, $value)
+    }};
+}
+
+macro_rules! make_table {
+    ($polynomial:expr, $reflect_in:expr, $reflect_out:expr) => {{
+        let mut table = [0; 256];
+        let bits = core::mem::size_of_val(&$polynomial) * 8;
+        let top_bit = 1 << (bits - 1);
+        let mut byte;
+
+        for i in 0..256 {
+            if $reflect_in {
+                byte = reflect_byte!(i);
+            } else {
+                byte = i;
+            }
+
+            // Shift the current table value "i" to the top byte in the long
+            let mut value = byte << (bits - 8);
+
+            // Step through all the bits in the byte
+            for _ in 0..8 {
+                if (value & top_bit) != 0 {
+                    value = (value << 1) ^ $polynomial
+                } else {
+                    value <<= 1
+                }
+            }
+
+            if $reflect_out {
+                value = reflect_value!(value);
+            }
+
+            table[i as usize] = value;
+        }
+
+        table
+    }};
+}
+
 /// Builds a CRC16 table using the standard or reflected method.
 /// If reflect==true, flip the individual byte bitwise, then flip the table value bitwise.
 pub fn make_table_crc16(poly: u16, reflect: bool) -> [u16; 256] {
-    let mut table = [0u16; 256];
-    let mut byte: u16;
-    let top_bit = 1u16 << 15; //15 is 16bit - 1
-
-    for i in 0..256 {
-        if reflect {
-            byte = reflect_byte_16(i);
-        } else {
-            byte = i;
-        }
-
-        // Shift the current table value "i" to the top byte in the long
-        let mut value: u16 = byte << 8; //8=16 bit - 8
-
-        // Step through all the bits in the byte
-        for _ in 0..8 {
-            if (value & top_bit) != 0 {
-                value = (value << 1) ^ poly
-            } else {
-                value <<= 1
-            }
-        }
-
-        if reflect {
-            value = reflect_value_16(value);
-        }
-
-        table[i as usize] = value;
-    }
-    table
+    make_table!(poly, reflect, reflect)
 }
 
 /// Builds a CRC32 table using the standard or reflected method.
 /// If reflect==true, flip the individual byte bitwise, then flip the table value bitwise.
 pub fn make_table_crc32(poly: u32, reflect: bool) -> [u32; 256] {
-    let mut table = [0u32; 256];
-    let mut byte: u32;
-    let top_bit = 1u32 << 31; //31 is 32bit - 1
-
-    for i in 0..256 {
-        if reflect {
-            byte = reflect_byte_32(i);
-        } else {
-            byte = i;
-        }
-
-        // Shift the current table value "i" to the top byte in the long
-        let mut value: u32 = byte << 24; //24=32 bit - 8
-
-        // Step through all the bits in the byte
-        for _ in 0..8 {
-            if (value & top_bit) != 0 {
-                value = (value << 1) ^ poly
-            } else {
-                value <<= 1
-            }
-        }
-
-        if reflect {
-            value = reflect_value_32(value);
-        }
-
-        table[i as usize] = value;
-    }
-    table
+    make_table!(poly, reflect, reflect)
 }
 
 /// Builds a CRC64 table using the standard or reflected method.
 /// If reflect==true, flip the individual byte bitwise, then flip the table value bitwise.
 pub fn make_table_crc64(poly: u64, reflect: bool) -> [u64; 256] {
-    let mut table = [0u64; 256];
-    let mut byte: u64;
-    let top_bit = 1u64 << 63; //63 is 64bit - 1
-
-    for i in 0..256 {
-        if reflect {
-            byte = reflect_byte_64(i);
-        } else {
-            byte = i as u64;
-        }
-
-        // Shift the current table value "i" to the top byte in the long
-        let mut value: u64 = byte << 56; //56=64 bit - 8
-
-        // Step through all the bits in the byte
-        for _ in 0..8 {
-            if (value & top_bit) != 0 {
-                value = (value << 1) ^ poly
-            } else {
-                value <<= 1
-            }
-        }
-
-        if reflect {
-            value = reflect_value_64(value);
-        }
-
-        table[i as usize] = value;
-    }
-    table
-}
-
-/// Reflects a value of a 16 bit number.
-fn reflect_value_16(mut value: u16) -> u16 {
-    let mut reflection: u16 = 0u16;
-    let bits = 16;
-
-    for i in 0..bits {
-        if (value & 0x01) == 1 {
-            reflection |= 1 << ((bits - 1) - i)
-        }
-        value >>= 1;
-    }
-    reflection
-}
-
-/// Reflects a value of a 32 bit number.
-fn reflect_value_32(mut value: u32) -> u32 {
-    let mut reflection: u32 = 0u32;
-    let bits = 32;
-
-    for i in 0..bits {
-        if (value & 0x01) == 1 {
-            reflection |= 1 << ((bits - 1) - i)
-        }
-        value >>= 1;
-    }
-    reflection
-}
-
-/// Reflects a value of a 64 bit number.
-fn reflect_value_64(mut value: u64) -> u64 {
-    let mut reflection: u64 = 0u64;
-    let bits = 64;
-
-    for i in 0..bits {
-        if (value & 0x01) == 1 {
-            reflection |= 1 << ((bits - 1) - i)
-        }
-        value >>= 1;
-    }
-    reflection
-}
-
-/// Reflects the least significant byte of a u16.
-fn reflect_byte_16(input: u16) -> u16 {
-    let mut reflection: u16 = 0u16;
-    let bits = 8;
-    let mut value = input;
-
-    for i in 0..bits {
-        if (value & 0x01) == 1 {
-            reflection |= 1 << ((bits - 1) - i)
-        }
-        value >>= 1;
-    }
-    reflection
-}
-
-/// Reflects the least significant byte of a u32.
-fn reflect_byte_32(input: u32) -> u32 {
-    let mut reflection: u32 = 0u32;
-    let bits = 8;
-    let mut value = input;
-
-    for i in 0..bits {
-        if (value & 0x01) == 1 {
-            reflection |= 1 << ((bits - 1) - i)
-        }
-        value >>= 1;
-    }
-    reflection
-}
-
-/// Reflects the least significant byte of a u64.
-fn reflect_byte_64(input: u64) -> u64 {
-    let mut reflection: u64 = 0u64;
-    let bits = 8;
-    let mut value = input;
-
-    for i in 0..bits {
-        if (value & 0x01) == 1 {
-            reflection |= 1 << ((bits - 1) - i)
-        }
-        value >>= 1;
-    }
-    reflection
+    make_table!(poly, reflect, reflect)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -37,7 +37,7 @@ macro_rules! make_table {
         let top_bit = 1 << (bits - 1);
         let mut byte;
 
-        for i in 0..256 {
+        for i in 0..=255 {
             if $reflect_in {
                 byte = reflect_byte!(i);
             } else {


### PR DESCRIPTION
DO NOT MERGE YET - Further testing required and feedback requested.

While exploring #45, I noticed that the logic used to create the u16/u32/u64 CRC tables is nearly identical. I was able to create a macro that generalizes the creation of these tables, and allows for reflection_in and reflection_out to be specified separately (needed for #45) .

I updated the implementations of make_table_crc16(), make_table_crc32(), and make_table_crc64() to simply call the macro, and all existing tests pass. However, I think more CRC variants should be tested before merging (in particular those with no reflection, or mixed input / output reflection).

Would you please take a look at the changes and let me know what you think? If you want to go this route then I will add test cases to hit the different combinations of input reflection and output reflection. The macro should also work for 8-bit (and even 128-bit) CRCs, if it is ever decided to add support for these in the future.