### PR TITLE
Use const fn

### DIFF
--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -8,13 +8,13 @@ impl Crc<u16> {
         Self { algorithm, table }
     }
 
-    pub fn checksum(&self, bytes: &[u8]) -> u16 {
+    pub const fn checksum(&self, bytes: &[u8]) -> u16 {
         let mut crc = self.init();
         crc = self.update(crc, bytes);
         self.finalize(crc)
     }
 
-    fn init(&self) -> u16 {
+    const fn init(&self) -> u16 {
         if self.algorithm.refin {
             reflect_16(self.algorithm.init)
         } else {
@@ -22,36 +22,40 @@ impl Crc<u16> {
         }
     }
 
-    fn table_entry(&self, index: u16) -> u16 {
+    const fn table_entry(&self, index: u16) -> u16 {
         self.table[(index & 0xFF) as usize]
     }
 
-    fn update(&self, crc: u16, bytes: &[u8]) -> u16 {
+    const fn update(&self, mut crc: u16, bytes: &[u8]) -> u16 {
+        let mut i = 0;
         if self.algorithm.refin {
-            bytes.iter().fold(crc, |crc, &byte| {
-                self.table_entry(crc ^ byte as u16) ^ (crc >> 8)
-            })
+            while i < bytes.len() {
+                crc = self.table_entry(crc ^ bytes[i] as u16) ^ (crc >> 8);
+                i += 1;
+            }
         } else {
-            bytes.iter().fold(crc, |crc, &byte| {
-                self.table_entry((byte as u16) ^ (crc >> 8)) ^ (crc << 8)
-            })
+            while i < bytes.len() {
+                crc = self.table_entry(bytes[i] as u16 ^ (crc >> 8)) ^ (crc << 8);
+                i += 1;
+            }
         }
+        crc
     }
 
-    fn finalize(&self, mut crc: u16) -> u16 {
+    const fn finalize(&self, mut crc: u16) -> u16 {
         if self.algorithm.refin ^ self.algorithm.refout {
             crc = reflect_16(crc);
         }
         crc ^ self.algorithm.xorout
     }
 
-    pub fn digest(&self) -> Digest<u16> {
+    pub const fn digest(&self) -> Digest<u16> {
         Digest::new(self)
     }
 }
 
 impl<'a> Digest<'a, u16> {
-    fn new(crc: &'a Crc<u16>) -> Self {
+    const fn new(crc: &'a Crc<u16>) -> Self {
         let value = crc.init();
         Digest { crc, value }
     }
@@ -60,7 +64,7 @@ impl<'a> Digest<'a, u16> {
         self.value = self.crc.update(self.value, bytes);
     }
 
-    pub fn finalize(self) -> u16 {
+    pub const fn finalize(self) -> u16 {
         self.crc.finalize(self.value)
     }
 }


### PR DESCRIPTION
Rust [1.46](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html) significantly extends `const fn` support, so now it's possible to perform all calculations at compile time (and hence invoke crc in const context). This PR makes all funcs const (with the only exception `Digest.update`, which mutates state and not yet available in stable).