### PR TITLE
Correct crc-catalog version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["algorithms", "no-std"]
 edition = "2018"
 
 [dependencies]
-crc-catalog = "1"
+crc-catalog = "1.1"
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
This crate says it works with crc-catalog 1.0.0, but it can't:

```
   Compiling crc v2.0.0-rc.1 (/opt/crc-rs)
error[E0310]: the parameter type `W` may not live long enough
  --> src/lib.rs:42:20
   |
41 | pub struct Crc<W: Width> {
   |                -- help: consider adding an explicit lifetime bound...: `W: 'static +`
42 |     pub algorithm: &'static Algorithm<W>,
   |                    ^^^^^^^^^^^^^^^^^^^^^ ...so that the reference type `&'static crc_catalog::Algorithm<W>` does not outlive the data it points at

error: aborting due to previous error

For more information about this error, try `rustc --explain E0310`.
error: could not compile `crc`

To learn more, run the command again with --verbose.
```
This matters when using `-Z minimal-versions` cargo option.