### PR TITLE
Prepare 2.1.0 release

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -19,6 +19,7 @@ jobs:
           profile: minimal
           toolchain: stable
           components: rustfmt, clippy
+          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -41,6 +42,7 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
+          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "crc"
-version = "2.0.1-alpha.0"
-authors = ["Rui Hu <code@mrhooray.com>"]
+version = "2.1.0"
+authors = [
+    "Rui Hu <code@mrhooray.com>",
+    "Akhil Velagapudi <4@4khil.com>"
+]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/mrhooray/crc-rs.git"
@@ -12,11 +15,4 @@ categories = ["algorithms", "no-std"]
 edition = "2018"
 
 [dependencies]
-crc-catalog = "1.1"
-
-[dev-dependencies]
-criterion = "0.3"
-
-[[bench]]
-name = "bench"
-harness = false
+crc-catalog = "1.1.1"


### PR DESCRIPTION
I think we're due a release, the crc-8 changes have been sitting in `master` for a while. Also, @mrhooray hope it's fine I added myself as an author considering https://github.com/mrhooray/crc-rs/pull/55.