### PR TITLE
Add Crc::digest_with_initial

### DIFF
--- a/src/crc128.rs
+++ b/src/crc128.rs
@@ -54,13 +54,17 @@ impl Crc<u128> {
     }
 
     pub const fn digest(&self) -> Digest<u128> {
-        Digest::new(self)
+        let initial = self.init();
+        Digest::new(self, initial)
+    }
+
+    pub const fn digest_with_initial(&self, initial: u128) -> Digest<u128> {
+        Digest::new(self, initial)
     }
 }
 
 impl<'a> Digest<'a, u128> {
-    const fn new(crc: &'a Crc<u128>) -> Self {
-        let value = crc.init();
+    const fn new(crc: &'a Crc<u128>, value: u128) -> Self {
         Digest { crc, value }
     }
 

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -54,13 +54,17 @@ impl Crc<u16> {
     }
 
     pub const fn digest(&self) -> Digest<u16> {
-        Digest::new(self)
+        let initial = self.init();
+        Digest::new(self, initial)
+    }
+
+    pub const fn digest_with_initial(&self, initial: u16) -> Digest<u16> {
+        Digest::new(self, initial)
     }
 }
 
 impl<'a> Digest<'a, u16> {
-    const fn new(crc: &'a Crc<u16>) -> Self {
-        let value = crc.init();
+    const fn new(crc: &'a Crc<u16>, value: u16) -> Self {
         Digest { crc, value }
     }
 

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -54,13 +54,17 @@ impl Crc<u32> {
     }
 
     pub const fn digest(&self) -> Digest<u32> {
-        Digest::new(self)
+        let initial = self.init();
+        Digest::new(self, initial)
+    }
+
+    pub const fn digest_with_initial(&self, initial: u32) -> Digest<u32> {
+        Digest::new(self, initial)
     }
 }
 
 impl<'a> Digest<'a, u32> {
-    const fn new(crc: &'a Crc<u32>) -> Self {
-        let value = crc.init();
+    const fn new(crc: &'a Crc<u32>, value: u32) -> Self {
         Digest { crc, value }
     }
 

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -54,13 +54,17 @@ impl Crc<u64> {
     }
 
     pub const fn digest(&self) -> Digest<u64> {
-        Digest::new(self)
+        let initial = self.init();
+        Digest::new(self, initial)
+    }
+
+    pub const fn digest_with_initial(&self, initial: u64) -> Digest<u64> {
+        Digest::new(self, initial)
     }
 }
 
 impl<'a> Digest<'a, u64> {
-    const fn new(crc: &'a Crc<u64>) -> Self {
-        let value = crc.init();
+    const fn new(crc: &'a Crc<u64>, value: u64) -> Self {
         Digest { crc, value }
     }
 

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -47,13 +47,17 @@ impl Crc<u8> {
     }
 
     pub const fn digest(&self) -> Digest<u8> {
-        Digest::new(self)
+        let initial = self.init();
+        Digest::new(self, initial)
+    }
+
+    pub const fn digest_with_initial(&self, initial: u8) -> Digest<u8> {
+        Digest::new(self, initial)
     }
 }
 
 impl<'a> Digest<'a, u8> {
-    const fn new(crc: &'a Crc<u8>) -> Self {
-        let value = crc.init();
+    const fn new(crc: &'a Crc<u8>, value: u8) -> Self {
         Digest { crc, value }
     }
 


### PR DESCRIPTION
It may sometimes be useful to compute CRC values with an initial value different from the one specified by the used algorithm.
In this case, users currently have to create a new `Algorithm` for each initial value.
This is particularly problematic if the initial values are not statically known, since `Crc::new` takes a static reference to an algorithm (see also #68).
With the small change proposed in this PR, an initial value may optionally be supplied when creating a `Digest`.
 