### PR TITLE
Add a const fn version of digest update

### DIFF
--- a/src/crc128.rs
+++ b/src/crc128.rs
@@ -68,6 +68,11 @@ impl<'a> Digest<'a, u128> {
         self.value = self.crc.update(self.value, bytes);
     }
 
+    pub const fn updated(mut self, bytes: &[u8]) -> Self {
+        self.value = self.crc.update(self.value, bytes);
+        self
+    }
+
     pub const fn finalize(self) -> u128 {
         self.crc.finalize(self.value)
     }

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -68,6 +68,11 @@ impl<'a> Digest<'a, u16> {
         self.value = self.crc.update(self.value, bytes);
     }
 
+    pub const fn updated(mut self, bytes: &[u8]) -> Self {
+        self.value = self.crc.update(self.value, bytes);
+        self
+    }
+
     pub const fn finalize(self) -> u16 {
         self.crc.finalize(self.value)
     }

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -68,6 +68,11 @@ impl<'a> Digest<'a, u32> {
         self.value = self.crc.update(self.value, bytes);
     }
 
+    pub const fn updated(mut self, bytes: &[u8]) -> Self {
+        self.value = self.crc.update(self.value, bytes);
+        self
+    }
+
     pub const fn finalize(self) -> u32 {
         self.crc.finalize(self.value)
     }

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -68,6 +68,11 @@ impl<'a> Digest<'a, u64> {
         self.value = self.crc.update(self.value, bytes);
     }
 
+    pub const fn updated(mut self, bytes: &[u8]) -> Self {
+        self.value = self.crc.update(self.value, bytes);
+        self
+    }
+
     pub const fn finalize(self) -> u64 {
         self.crc.finalize(self.value)
     }

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -61,6 +61,11 @@ impl<'a> Digest<'a, u8> {
         self.value = self.crc.update(self.value, bytes);
     }
 
+    pub const fn updated(mut self, bytes: &[u8]) -> Self {
+        self.value = self.crc.update(self.value, bytes);
+        self
+    }
+
     pub const fn finalize(self) -> u8 {
         self.crc.finalize(self.value)
     }


### PR DESCRIPTION
So for context, I'm working on a library for a special type of hash which involves a CRC32, but the implementation takes every character and makes it lowercase (ascii_lowercase) before it's hashed. Since this is a const fn, I'm not able to create a new allocations for the lowercased version. I've tried const generics, but that requires always knowing the input length at compile time, which is too restrictive. I've found a way to do this, by adding a const fn version of the update function in Digest, which I've implemented here