### PR TITLE
Add slice16

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -11,12 +11,17 @@ pub const DARC: Crc<u128> = Crc::<u128>::new(&CRC_82_DARC);
 
 static KB: usize = 1024;
 
+fn baseline(data: &[u8]) -> usize {
+    data.iter().fold(0usize, |acc, v| acc.wrapping_add(*v as usize))
+}
+
 fn checksum(c: &mut Criterion) {
     let size = 16 * KB;
     let bytes = vec![0u8; size];
 
     c.benchmark_group("checksum")
         .throughput(Throughput::Bytes(size as u64))
+        .bench_function("baseline", |b| b.iter(|| baseline(black_box(&bytes))))
         .bench_function("crc8", |b| b.iter(|| BLUETOOTH.checksum(black_box(&bytes))))
         .bench_function("crc16", |b| b.iter(|| X25.checksum(black_box(&bytes))))
         .bench_function("crc32", |b| b.iter(|| ISCSI.checksum(black_box(&bytes))))

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,7 +4,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughpu
 pub const BLUETOOTH: Crc<u8> = Crc::<u8>::new(&CRC_8_BLUETOOTH);
 pub const X25: Crc<u16> = Crc::<u16>::new(&CRC_16_IBM_SDLC);
 pub const ISCSI: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
-pub const ISCSI_SLICE16: Crc<FastU32> = Crc::<FastU32>::new(&CRC_32_ISCSI);
+pub const ISCSI_SLICE16: Crc<Slice16<u32>> = Crc::<Slice16<u32>>::new(&CRC_32_ISCSI);
 pub const GSM_40: Crc<u64> = Crc::<u64>::new(&CRC_40_GSM);
 pub const ECMA: Crc<u64> = Crc::<u64>::new(&CRC_64_ECMA_182);
 pub const DARC: Crc<u128> = Crc::<u128>::new(&CRC_82_DARC);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,6 +4,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughpu
 pub const BLUETOOTH: Crc<u8> = Crc::<u8>::new(&CRC_8_BLUETOOTH);
 pub const X25: Crc<u16> = Crc::<u16>::new(&CRC_16_IBM_SDLC);
 pub const ISCSI: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
+pub const ISCSI_SLICE16: Crc<FastU32> = Crc::<FastU32>::new(&CRC_32_ISCSI);
 pub const GSM_40: Crc<u64> = Crc::<u64>::new(&CRC_40_GSM);
 pub const ECMA: Crc<u64> = Crc::<u64>::new(&CRC_64_ECMA_182);
 pub const DARC: Crc<u128> = Crc::<u128>::new(&CRC_82_DARC);
@@ -19,6 +20,9 @@ fn checksum(c: &mut Criterion) {
         .bench_function("crc8", |b| b.iter(|| BLUETOOTH.checksum(black_box(&bytes))))
         .bench_function("crc16", |b| b.iter(|| X25.checksum(black_box(&bytes))))
         .bench_function("crc32", |b| b.iter(|| ISCSI.checksum(black_box(&bytes))))
+        .bench_function("crc32_slice16", |b| {
+            b.iter(|| ISCSI_SLICE16.checksum(black_box(&bytes)))
+        })
         .bench_function("crc40", |b| b.iter(|| GSM_40.checksum(black_box(&bytes))))
         .bench_function("crc64", |b| b.iter(|| ECMA.checksum(black_box(&bytes))))
         .bench_function("crc82", |b| b.iter(|| DARC.checksum(black_box(&bytes))));

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -12,7 +12,8 @@ pub const DARC: Crc<u128> = Crc::<u128>::new(&CRC_82_DARC);
 static KB: usize = 1024;
 
 fn baseline(data: &[u8]) -> usize {
-    data.iter().fold(0usize, |acc, v| acc.wrapping_add(*v as usize))
+    data.iter()
+        .fold(0usize, |acc, v| acc.wrapping_add(*v as usize))
 }
 
 fn checksum(c: &mut Criterion) {

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -3,8 +3,11 @@ use crate::table::crc32_table;
 
 impl Crc<u32> {
     pub const fn new(algorithm: &'static Algorithm<u32>) -> Self {
-        let table = crc32_table(algorithm.width, algorithm.poly, algorithm.refin);
-        Self { algorithm, table }
+        let table = crc32_table::<1>(algorithm.width, algorithm.poly, algorithm.refin);
+        Self {
+            algorithm,
+            table: table[0],
+        }
     }
 
     pub const fn checksum(&self, bytes: &[u8]) -> u32 {

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -3,11 +3,8 @@ use crate::table::crc32_table;
 
 impl Crc<u32> {
     pub const fn new(algorithm: &'static Algorithm<u32>) -> Self {
-        let table = crc32_table::<1>(algorithm.width, algorithm.poly, algorithm.refin);
-        Self {
-            algorithm,
-            table: table[0],
-        }
+        let table = crc32_table(algorithm.width, algorithm.poly, algorithm.refin);
+        Self { algorithm, table }
     }
 
     pub const fn checksum(&self, bytes: &[u8]) -> u32 {

--- a/src/crc32_fast.rs
+++ b/src/crc32_fast.rs
@@ -1,5 +1,5 @@
 use super::{Algorithm, Crc, Digest};
-use crate::table::crc32_table;
+use crate::table::crc32_table_slice_16;
 
 /// This implements a faster version of Crc<u32> with a 16kB lookup table
 pub struct FastU32;
@@ -13,7 +13,7 @@ impl crate::Implementation for FastU32 {
 
 impl Crc<FastU32> {
     pub const fn new(algorithm: &'static Algorithm<u32>) -> Self {
-        let table = crc32_table::<16>(algorithm.width, algorithm.poly, algorithm.refin);
+        let table = crc32_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
         Self { algorithm, table }
     }
 

--- a/src/crc32_fast.rs
+++ b/src/crc32_fast.rs
@@ -1,5 +1,5 @@
 use super::{Algorithm, Crc, Digest};
-use crate::{table::crc32_table};
+use crate::table::crc32_table;
 
 /// This implements a faster version of Crc<u32> with a 16kB lookup table
 pub struct FastU32;

--- a/src/crc32_fast.rs
+++ b/src/crc32_fast.rs
@@ -163,54 +163,33 @@ fn correctness() {
         residue: 0xb798b438,
     };
 
-    let iscsi = Crc::<Slice16<u32>>::new(&CRC_32_ISCSI);
-    let iscsi_nonreflex = Crc::<Slice16<u32>>::new(&CRC_32_ISCSI_NONREFLEX);
+    let algs_to_test = [&CRC_32_ISCSI, &CRC_32_ISCSI_NONREFLEX];
 
-    for data in data {
-        let expected = Crc::<u32>::new(&CRC_32_ISCSI).checksum(data.as_bytes());
+    for alg in algs_to_test {
+        for data in data {
+            let test_crc = Crc::<Slice16<u32>>::new(alg);
+            let expected = Crc::<u32>::new(alg).checksum(data.as_bytes());
 
-        // Check that doing all at once works as expected
-        let crc1 = iscsi.checksum(data.as_bytes());
-        assert_eq!(crc1, expected);
+            // Check that doing all at once works as expected
+            let crc1 = test_crc.checksum(data.as_bytes());
+            assert_eq!(crc1, expected);
 
-        let mut digest = iscsi.digest();
-        digest.update(data.as_bytes());
-        let crc2 = digest.finalize();
-        assert_eq!(crc2, expected);
+            let mut digest = test_crc.digest();
+            digest.update(data.as_bytes());
+            let crc2 = digest.finalize();
+            assert_eq!(crc2, expected);
 
-        // Check that we didn't break updating from multiple sources
-        if data.len() > 2 {
-            let data = data.as_bytes();
-            let data1 = &data[..data.len() / 2];
-            let data2 = &data[data.len() / 2..];
-            let mut digest = iscsi.digest();
-            digest.update(data1);
-            digest.update(data2);
-            let crc3 = digest.finalize();
-            assert_eq!(crc3, expected);
-        }
-
-        let expected = Crc::<u32>::new(&CRC_32_ISCSI_NONREFLEX).checksum(data.as_bytes());
-
-        // Check that doing all at once works as expected
-        let crc1 = iscsi_nonreflex.checksum(data.as_bytes());
-        assert_eq!(crc1, expected);
-
-        let mut digest = iscsi_nonreflex.digest();
-        digest.update(data.as_bytes());
-        let crc2 = digest.finalize();
-        assert_eq!(crc2, expected);
-
-        // Check that we didn't break updating from multiple sources
-        if data.len() > 2 {
-            let data = data.as_bytes();
-            let data1 = &data[..data.len() / 2];
-            let data2 = &data[data.len() / 2..];
-            let mut digest = iscsi_nonreflex.digest();
-            digest.update(data1);
-            digest.update(data2);
-            let crc3 = digest.finalize();
-            assert_eq!(crc3, expected);
+            // Check that we didn't break updating from multiple sources
+            if data.len() > 2 {
+                let data = data.as_bytes();
+                let data1 = &data[..data.len() / 2];
+                let data2 = &data[data.len() / 2..];
+                let mut digest = test_crc.digest();
+                digest.update(data1);
+                digest.update(data2);
+                let crc3 = digest.finalize();
+                assert_eq!(crc3, expected);
+            }
         }
     }
 }

--- a/src/crc32_fast.rs
+++ b/src/crc32_fast.rs
@@ -1,0 +1,226 @@
+use super::{Algorithm, Crc, Digest};
+use crate::{table::crc32_table};
+
+/// This implements a faster version of Crc<u32> with a 16kB lookup table
+pub struct FastU32;
+
+impl crate::private::Sealed for FastU32 {}
+
+impl crate::Implementation for FastU32 {
+    type Width = u32;
+    type Table = [[u32; 256]; 16];
+}
+
+impl Crc<FastU32> {
+    pub const fn new(algorithm: &'static Algorithm<u32>) -> Self {
+        let table = crc32_table::<16>(algorithm.width, algorithm.poly, algorithm.refin);
+        Self { algorithm, table }
+    }
+
+    pub const fn checksum(&self, bytes: &[u8]) -> u32 {
+        let mut crc = self.init(self.algorithm.init);
+        crc = self.update(crc, bytes);
+        self.finalize(crc)
+    }
+
+    const fn init(&self, initial: u32) -> u32 {
+        if self.algorithm.refin {
+            initial.reverse_bits() >> (32u8 - self.algorithm.width)
+        } else {
+            initial << (32u8 - self.algorithm.width)
+        }
+    }
+
+    const fn update(&self, mut crc: u32, bytes: &[u8]) -> u32 {
+        let mut i = 0;
+        if self.algorithm.refin {
+            while i + 16 <= bytes.len() {
+                let mut current_slice = [bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3]];
+
+                current_slice[0] ^= crc as u8;
+                current_slice[1] ^= (crc >> 8) as u8;
+                current_slice[2] ^= (crc >> 16) as u8;
+                current_slice[3] ^= (crc >> 24) as u8;
+
+                crc = self.table[0][bytes[i + 15] as usize]
+                    ^ self.table[1][bytes[i + 14] as usize]
+                    ^ self.table[2][bytes[i + 13] as usize]
+                    ^ self.table[3][bytes[i + 12] as usize]
+                    ^ self.table[4][bytes[i + 11] as usize]
+                    ^ self.table[5][bytes[i + 10] as usize]
+                    ^ self.table[6][bytes[i + 9] as usize]
+                    ^ self.table[7][bytes[i + 8] as usize]
+                    ^ self.table[8][bytes[i + 7] as usize]
+                    ^ self.table[9][bytes[i + 6] as usize]
+                    ^ self.table[10][bytes[i + 5] as usize]
+                    ^ self.table[11][bytes[i + 4] as usize]
+                    ^ self.table[12][current_slice[3] as usize]
+                    ^ self.table[13][current_slice[2] as usize]
+                    ^ self.table[14][current_slice[1] as usize]
+                    ^ self.table[15][current_slice[0] as usize];
+
+                i += 16;
+            }
+
+            // Last few bytes
+            while i < bytes.len() {
+                let table_index = ((crc ^ bytes[i] as u32) & 0xFF) as usize;
+                crc = self.table[0][table_index] ^ (crc >> 8);
+                i += 1;
+            }
+        } else {
+            while i + 16 <= bytes.len() {
+                let mut current_slice = [bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3]];
+
+                current_slice[0] ^= (crc >> 24) as u8;
+                current_slice[1] ^= (crc >> 16) as u8;
+                current_slice[2] ^= (crc >> 8) as u8;
+                current_slice[3] ^= crc as u8;
+
+                crc = self.table[0][bytes[i + 15] as usize]
+                    ^ self.table[1][bytes[i + 14] as usize]
+                    ^ self.table[2][bytes[i + 13] as usize]
+                    ^ self.table[3][bytes[i + 12] as usize]
+                    ^ self.table[4][bytes[i + 11] as usize]
+                    ^ self.table[5][bytes[i + 10] as usize]
+                    ^ self.table[6][bytes[i + 9] as usize]
+                    ^ self.table[7][bytes[i + 8] as usize]
+                    ^ self.table[8][bytes[i + 7] as usize]
+                    ^ self.table[9][bytes[i + 6] as usize]
+                    ^ self.table[10][bytes[i + 5] as usize]
+                    ^ self.table[11][bytes[i + 4] as usize]
+                    ^ self.table[12][current_slice[3] as usize]
+                    ^ self.table[13][current_slice[2] as usize]
+                    ^ self.table[14][current_slice[1] as usize]
+                    ^ self.table[15][current_slice[0] as usize];
+
+                i += 16;
+            }
+
+            // Last few bytes
+            while i < bytes.len() {
+                let table_index = (((crc >> 24) ^ bytes[i] as u32) & 0xFF) as usize;
+                crc = self.table[0][table_index] ^ (crc << 8);
+                i += 1;
+            }
+        }
+        crc
+    }
+
+    const fn finalize(&self, mut crc: u32) -> u32 {
+        if self.algorithm.refin ^ self.algorithm.refout {
+            crc = crc.reverse_bits();
+        }
+        if !self.algorithm.refout {
+            crc >>= 32u8 - self.algorithm.width;
+        }
+        crc ^ self.algorithm.xorout
+    }
+
+    pub const fn digest(&self) -> Digest<FastU32> {
+        self.digest_with_initial(self.algorithm.init)
+    }
+
+    /// Construct a `Digest` with a given initial value.
+    ///
+    /// This overrides the initial value specified by the algorithm.
+    /// The effects of the algorithm's properties `refin` and `width`
+    /// are applied to the custom initial value.
+    pub const fn digest_with_initial(&self, initial: u32) -> Digest<FastU32> {
+        let value = self.init(initial);
+        Digest::new(self, value)
+    }
+}
+
+impl<'a> Digest<'a, FastU32> {
+    const fn new(crc: &'a Crc<FastU32>, value: u32) -> Self {
+        Digest { crc, value }
+    }
+
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.value = self.crc.update(self.value, bytes);
+    }
+
+    pub const fn finalize(self) -> u32 {
+        self.crc.finalize(self.value)
+    }
+}
+
+/// Test this opitimized version against the well known implementation to ensure correctness
+#[test]
+fn correctness() {
+    use crc_catalog::CRC_32_ISCSI;
+
+    let data: &[&str] = &[
+        "",
+        "1",
+        "1234",
+        "123456789",
+        "0123456789ABCDE",
+        "01234567890ABCDEFGHIJK",
+        "01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK",
+    ];
+
+    pub const CRC_32_ISCSI_NONREFLEX: Algorithm<u32> = Algorithm {
+        width: 32,
+        poly: 0x1edc6f41,
+        init: 0xffffffff,
+        // This is the only flag that affects the optimized code path
+        refin: false,
+        refout: true,
+        xorout: 0xffffffff,
+        check: 0xe3069283,
+        residue: 0xb798b438,
+    };
+
+    let iscsi = Crc::<FastU32>::new(&CRC_32_ISCSI);
+    let iscsi_nonreflex = Crc::<FastU32>::new(&CRC_32_ISCSI_NONREFLEX);
+
+    for data in data {
+        let expected = Crc::<u32>::new(&CRC_32_ISCSI).checksum(data.as_bytes());
+
+        // Check that doing all at once works as expected
+        let crc1 = iscsi.checksum(data.as_bytes());
+        assert_eq!(crc1, expected);
+
+        let mut digest = iscsi.digest();
+        digest.update(data.as_bytes());
+        let crc2 = digest.finalize();
+        assert_eq!(crc2, expected);
+
+        // Check that we didn't break updating from multiple sources
+        if data.len() > 2 {
+            let data = data.as_bytes();
+            let data1 = &data[..data.len() / 2];
+            let data2 = &data[data.len() / 2..];
+            let mut digest = iscsi.digest();
+            digest.update(data1);
+            digest.update(data2);
+            let crc3 = digest.finalize();
+            assert_eq!(crc3, expected);
+        }
+
+        let expected = Crc::<u32>::new(&CRC_32_ISCSI_NONREFLEX).checksum(data.as_bytes());
+
+        // Check that doing all at once works as expected
+        let crc1 = iscsi_nonreflex.checksum(data.as_bytes());
+        assert_eq!(crc1, expected);
+
+        let mut digest = iscsi_nonreflex.digest();
+        digest.update(data.as_bytes());
+        let crc2 = digest.finalize();
+        assert_eq!(crc2, expected);
+
+        // Check that we didn't break updating from multiple sources
+        if data.len() > 2 {
+            let data = data.as_bytes();
+            let data1 = &data[..data.len() / 2];
+            let data2 = &data[data.len() / 2..];
+            let mut digest = iscsi_nonreflex.digest();
+            digest.update(data1);
+            digest.update(data2);
+            let crc3 = digest.finalize();
+            assert_eq!(crc3, expected);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,13 +36,21 @@ pub use crc_catalog::*;
 mod crc128;
 mod crc16;
 mod crc32;
+mod crc32_fast;
 mod crc64;
 mod crc8;
 mod table;
 mod util;
 
-mod crc32_fast;
-pub use crc32_fast::FastU32;
+/// For some widths there is a faster implementation using a 16x larger lookup table. Use it with `Crc<Slice16<W>>`
+pub struct Slice16<W: Width>(core::marker::PhantomData<W>);
+
+impl<W: Width> crate::private::Sealed for Slice16<W> {}
+
+impl<W: Width> crate::Implementation for Slice16<W> {
+    type Width = W;
+    type Table = [[W; 256]; 16];
+}
 
 mod private {
     pub trait Sealed {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,10 @@ mod crc8;
 mod table;
 mod util;
 
+
+mod crc32_fast;
+pub use crc32_fast::FastU32;
+
 mod private {
     pub trait Sealed {}
     impl<W: super::Width> Sealed for W {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@ mod crc8;
 mod table;
 mod util;
 
-
 mod crc32_fast;
 pub use crc32_fast::FastU32;
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -34,11 +34,7 @@ pub(crate) const fn crc16_table(width: u8, poly: u16, reflect: bool) -> [u16; 25
     table
 }
 
-pub(crate) const fn crc32_table<const LEVEL: usize>(
-    width: u8,
-    poly: u32,
-    reflect: bool,
-) -> [[u32; 256]; LEVEL] {
+pub(crate) const fn crc32_table(width: u8, poly: u32, reflect: bool) -> [u32; 256] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
         poly >> (32u8 - width)
@@ -46,7 +42,25 @@ pub(crate) const fn crc32_table<const LEVEL: usize>(
         poly << (32u8 - width)
     };
 
-    let mut table = [[0u32; 256]; LEVEL];
+    let mut table = [0u32; 256];
+    let mut i = 0;
+    while i < 256 {
+        table[i] = crc32(poly, reflect, i as u32);
+        i += 1;
+    }
+
+    table
+}
+
+pub(crate) const fn crc32_table_slice_16(width: u8, poly: u32, reflect: bool) -> [[u32; 256]; 16] {
+    let poly = if reflect {
+        let poly = poly.reverse_bits();
+        poly >> (32u8 - width)
+    } else {
+        poly << (32u8 - width)
+    };
+
+    let mut table = [[0u32; 256]; 16];
     let mut i = 0;
     while i < 256 {
         table[0][i] = crc32(poly, reflect, i as u32);
@@ -56,7 +70,7 @@ pub(crate) const fn crc32_table<const LEVEL: usize>(
     let mut i = 0;
     while i < 256 {
         let mut e = 1;
-        while e < LEVEL {
+        while e < 16 {
             let one_lower = table[e - 1][i];
             if reflect {
                 table[e][i] = (one_lower >> 8) ^ table[0][(one_lower & 0xFF) as usize];


### PR DESCRIPTION
This introduces an implementation of the slice-by-16 algorithm that calculates the crc of 16 bytes in one step instead of iterating the input bytewise. As a tradeoff the necessary lookup-table is 16x bigger, so in case of a 32bit crc it's 16kB.

Should I add implementations for the other widths in this PR or do you prefer separate PRs? I'd imagine review is simpler in separate PRs but merging the benchmarks might get annoying. I don't really care, I can do both.

Benchmark on a Ryzen 7 3800X:

```
$ cargo bench 32

     Running benches/bench.rs (target/release/deps/bench-9c684e23a65bab14)
checksum/crc32          time:   [30.355 µs 30.357 µs 30.360 µs]
                        thrpt:  [514.66 MiB/s 514.70 MiB/s 514.75 MiB/s]
                 
checksum/crc32_slice16  time:   [4.5740 µs 4.5812 µs 4.5893 µs]
                        thrpt:  [3.3249 GiB/s 3.3308 GiB/s 3.3360 GiB/s]

checksum/baseline       time:   [3.7496 µs 3.7515 µs 3.7537 µs]
                        thrpt:  [4.0650 GiB/s 4.0674 GiB/s 4.0694 GiB/s]
``` 

Benchmark on a Mac Studio:

```
checksum/crc32          time:   [41.819 µs 41.900 µs 41.966 µs]
                        thrpt:  [372.32 MiB/s 372.91 MiB/s 373.63 MiB/s]
                       
checksum/crc32_slice16  time:   [4.6718 µs 4.6765 µs 4.6808 µs]
                        thrpt:  [3.2599 GiB/s 3.2629 GiB/s 3.2661 GiB/s]
                  
checksum/baseline       time:   [1.1513 µs 1.1525 µs 1.1537 µs]
                        thrpt:  [13.226 GiB/s 13.240 GiB/s 13.254 GiB/s]
```

# Open questions
## Should this be the default? 

I don't think a 16kB lookup table is too much and this would automatically improve speeds in all using crates. I could swap the logic pretty easily and make this the impl for `Crc<u32>` and provide a `BytewiseU32` instead, that uses the current `Crc<u32>` implementation. Otherwise the improvements will probably take quite a while to actually reach end-users. 

# To-dos
* [x] Need to remove the const generic trick used to build the tables because it's not supported in rust 1.46