### PR TITLE
implement slice16 and no-table implementations for width 64

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,6 +9,9 @@ pub const ISCSI_BYTEWISE: Crc<Bytewise<u32>> = Crc::<Bytewise<u32>>::new(&CRC_32
 pub const ISCSI_NOLOOKUP: Crc<NoTable<u32>> = Crc::<NoTable<u32>>::new(&CRC_32_ISCSI);
 pub const GSM_40: Crc<u64> = Crc::<u64>::new(&CRC_40_GSM);
 pub const ECMA: Crc<u64> = Crc::<u64>::new(&CRC_64_ECMA_182);
+pub const ECMA_SLICE16: Crc<Slice16<u64>> = Crc::<Slice16<u64>>::new(&CRC_64_ECMA_182);
+pub const ECMA_BYTEWISE: Crc<Bytewise<u64>> = Crc::<Bytewise<u64>>::new(&CRC_64_ECMA_182);
+pub const ECMA_NOLOOKUP: Crc<NoTable<u64>> = Crc::<NoTable<u64>>::new(&CRC_64_ECMA_182);
 pub const DARC: Crc<u128> = Crc::<u128>::new(&CRC_82_DARC);
 
 static KB: usize = 1024;
@@ -39,11 +42,23 @@ fn checksum(c: &mut Criterion) {
             b.iter(|| ISCSI_SLICE16.checksum(black_box(&bytes)))
         });
 
+    c.benchmark_group("crc64")
+        .throughput(Throughput::Bytes(size as u64))
+        .bench_function("default", |b| b.iter(|| ECMA.checksum(black_box(&bytes))))
+        .bench_function("nolookup", |b| {
+            b.iter(|| ECMA_NOLOOKUP.checksum(black_box(&bytes)))
+        })
+        .bench_function("bytewise", |b| {
+            b.iter(|| ECMA_BYTEWISE.checksum(black_box(&bytes)))
+        })
+        .bench_function("slice16", |b| {
+            b.iter(|| ECMA_SLICE16.checksum(black_box(&bytes)))
+        });
+
     c.benchmark_group("checksum")
         .bench_function("crc8", |b| b.iter(|| BLUETOOTH.checksum(black_box(&bytes))))
         .bench_function("crc16", |b| b.iter(|| X25.checksum(black_box(&bytes))))
         .bench_function("crc40", |b| b.iter(|| GSM_40.checksum(black_box(&bytes))))
-        .bench_function("crc64", |b| b.iter(|| ECMA.checksum(black_box(&bytes))))
         .bench_function("crc82", |b| b.iter(|| DARC.checksum(black_box(&bytes))));
 }
 

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -1,83 +1,222 @@
-use super::{Algorithm, Crc, Digest};
-use crate::table::crc64_table;
+use crc_catalog::Algorithm;
 
-impl Crc<u64> {
-    pub const fn new(algorithm: &'static Algorithm<u64>) -> Self {
-        let table = crc64_table(algorithm.width, algorithm.poly, algorithm.refin);
-        Self { algorithm, table }
-    }
+use crate::util::crc64;
 
-    pub const fn checksum(&self, bytes: &[u8]) -> u64 {
-        let mut crc = self.init(self.algorithm.init);
-        crc = self.update(crc, bytes);
-        self.finalize(crc)
-    }
+mod bytewise;
+mod default;
+mod nolookup;
+mod slice16;
 
-    const fn init(&self, initial: u64) -> u64 {
-        if self.algorithm.refin {
-            initial.reverse_bits() >> (64u8 - self.algorithm.width)
-        } else {
-            initial << (64u8 - self.algorithm.width)
-        }
-    }
-
-    const fn table_entry(&self, index: u64) -> u64 {
-        self.table[(index & 0xFF) as usize]
-    }
-
-    const fn update(&self, mut crc: u64, bytes: &[u8]) -> u64 {
-        let mut i = 0;
-        if self.algorithm.refin {
-            while i < bytes.len() {
-                let table_index = crc ^ bytes[i] as u64;
-                crc = self.table_entry(table_index) ^ (crc >> 8);
-                i += 1;
-            }
-        } else {
-            while i < bytes.len() {
-                let table_index = (crc >> 56) ^ bytes[i] as u64;
-                crc = self.table_entry(table_index) ^ (crc << 8);
-                i += 1;
-            }
-        }
-        crc
-    }
-
-    const fn finalize(&self, mut crc: u64) -> u64 {
-        if self.algorithm.refin ^ self.algorithm.refout {
-            crc = crc.reverse_bits();
-        }
-        if !self.algorithm.refout {
-            crc >>= 64u8 - self.algorithm.width;
-        }
-        crc ^ self.algorithm.xorout
-    }
-
-    pub const fn digest(&self) -> Digest<u64> {
-        self.digest_with_initial(self.algorithm.init)
-    }
-
-    /// Construct a `Digest` with a given initial value.
-    ///
-    /// This overrides the initial value specified by the algorithm.
-    /// The effects of the algorithm's properties `refin` and `width`
-    /// are applied to the custom initial value.
-    pub const fn digest_with_initial(&self, initial: u64) -> Digest<u64> {
-        let value = self.init(initial);
-        Digest::new(self, value)
+const fn init(algorithm: &Algorithm<u64>, initial: u64) -> u64 {
+    if algorithm.refin {
+        initial.reverse_bits() >> (64u8 - algorithm.width)
+    } else {
+        initial << (64u8 - algorithm.width)
     }
 }
 
-impl<'a> Digest<'a, u64> {
-    const fn new(crc: &'a Crc<u64>, value: u64) -> Self {
-        Digest { crc, value }
+const fn finalize(algorithm: &Algorithm<u64>, mut crc: u64) -> u64 {
+    if algorithm.refin ^ algorithm.refout {
+        crc = crc.reverse_bits();
     }
-
-    pub fn update(&mut self, bytes: &[u8]) {
-        self.value = self.crc.update(self.value, bytes);
+    if !algorithm.refout {
+        crc >>= 64u8 - algorithm.width;
     }
+    crc ^ algorithm.xorout
+}
 
-    pub const fn finalize(self) -> u64 {
-        self.crc.finalize(self.value)
+const fn update_nolookup(mut crc: u64, algorithm: &Algorithm<u64>, bytes: &[u8]) -> u64 {
+    let poly = if algorithm.refin {
+        let poly = algorithm.poly.reverse_bits();
+        poly >> (64u8 - algorithm.width)
+    } else {
+        algorithm.poly << (64u8 - algorithm.width)
+    };
+
+    let mut i = 0;
+    if algorithm.refin {
+        while i < bytes.len() {
+            let to_crc = (crc ^ bytes[i] as u64) & 0xFF;
+            crc = crc64(poly, algorithm.refin, to_crc) ^ (crc >> 8);
+            i += 1;
+        }
+    } else {
+        while i < bytes.len() {
+            let to_crc = ((crc >> 56) ^ bytes[i] as u64) & 0xFF;
+            crc = crc64(poly, algorithm.refin, to_crc) ^ (crc << 8);
+            i += 1;
+        }
+    }
+    crc
+}
+
+const fn update_bytewise(mut crc: u64, reflect: bool, table: &[u64; 256], bytes: &[u8]) -> u64 {
+    let mut i = 0;
+    let len = bytes.len();
+    if reflect {
+        while i < len {
+            let table_index = ((crc ^ bytes[i] as u64) & 0xFF) as usize;
+            crc = table[table_index] ^ (crc >> 8);
+            i += 1;
+        }
+    } else {
+        while i < len {
+            let table_index = (((crc >> 56) ^ bytes[i] as u64) & 0xFF) as usize;
+            crc = table[table_index] ^ (crc << 8);
+            i += 1;
+        }
+    }
+    crc
+}
+
+const fn update_slice16(
+    mut crc: u64,
+    reflect: bool,
+    table: &[[u64; 256]; 16],
+    bytes: &[u8],
+) -> u64 {
+    let mut i = 0;
+    let len = bytes.len();
+    if reflect {
+        while i + 16 < len {
+            let current0 = bytes[i] ^ crc as u8;
+            let current1 = bytes[i + 1] ^ (crc >> 8) as u8;
+            let current2 = bytes[i + 2] ^ (crc >> 16) as u8;
+            let current3 = bytes[i + 3] ^ (crc >> 24) as u8;
+            let current4 = bytes[i + 4] ^ (crc >> 32) as u8;
+            let current5 = bytes[i + 5] ^ (crc >> 40) as u8;
+            let current6 = bytes[i + 6] ^ (crc >> 48) as u8;
+            let current7 = bytes[i + 7] ^ (crc >> 56) as u8;
+
+            crc = table[0][bytes[i + 15] as usize]
+                ^ table[1][bytes[i + 14] as usize]
+                ^ table[2][bytes[i + 13] as usize]
+                ^ table[3][bytes[i + 12] as usize]
+                ^ table[4][bytes[i + 11] as usize]
+                ^ table[5][bytes[i + 10] as usize]
+                ^ table[6][bytes[i + 9] as usize]
+                ^ table[7][bytes[i + 8] as usize]
+                ^ table[8][current7 as usize]
+                ^ table[9][current6 as usize]
+                ^ table[10][current5 as usize]
+                ^ table[11][current4 as usize]
+                ^ table[12][current3 as usize]
+                ^ table[13][current2 as usize]
+                ^ table[14][current1 as usize]
+                ^ table[15][current0 as usize];
+
+            i += 16;
+        }
+
+        while i < len {
+            let table_index = ((crc ^ bytes[i] as u64) & 0xFF) as usize;
+            crc = table[0][table_index] ^ (crc >> 8);
+            i += 1;
+        }
+    } else {
+        while i + 16 < len {
+            let current0 = bytes[i] ^ (crc >> 56) as u8;
+            let current1 = bytes[i + 1] ^ (crc >> 48) as u8;
+            let current2 = bytes[i + 2] ^ (crc >> 40) as u8;
+            let current3 = bytes[i + 3] ^ (crc >> 32) as u8;
+            let current4 = bytes[i + 4] ^ (crc >> 24) as u8;
+            let current5 = bytes[i + 5] ^ (crc >> 16) as u8;
+            let current6 = bytes[i + 6] ^ (crc >> 8) as u8;
+            let current7 = bytes[i + 7] ^ crc as u8;
+
+            crc = table[0][bytes[i + 15] as usize]
+                ^ table[1][bytes[i + 14] as usize]
+                ^ table[2][bytes[i + 13] as usize]
+                ^ table[3][bytes[i + 12] as usize]
+                ^ table[4][bytes[i + 11] as usize]
+                ^ table[5][bytes[i + 10] as usize]
+                ^ table[6][bytes[i + 9] as usize]
+                ^ table[7][bytes[i + 8] as usize]
+                ^ table[8][current7 as usize]
+                ^ table[9][current6 as usize]
+                ^ table[10][current5 as usize]
+                ^ table[11][current4 as usize]
+                ^ table[12][current3 as usize]
+                ^ table[13][current2 as usize]
+                ^ table[14][current1 as usize]
+                ^ table[15][current0 as usize];
+
+            i += 16;
+        }
+
+        while i < len {
+            let table_index = (((crc >> 56) ^ bytes[i] as u64) & 0xFF) as usize;
+            crc = table[0][table_index] ^ (crc << 8);
+            i += 1;
+        }
+    }
+    crc
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{Bytewise, Crc, NoTable, Slice16};
+    use crc_catalog::{Algorithm, CRC_64_ECMA_182};
+
+    /// Test this opitimized version against the well known implementation to ensure correctness
+    #[test]
+    fn correctness() {
+        let data: &[&str] = &[
+        "",
+        "1",
+        "1234",
+        "123456789",
+        "0123456789ABCDE",
+        "01234567890ABCDEFGHIJK",
+        "01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK",
+    ];
+
+        pub const CRC_64_ECMA_182_REFLEX: Algorithm<u64> = Algorithm {
+            width: 64,
+            poly: 0x42f0e1eba9ea3693,
+            init: 0x0000000000000000,
+            refin: true,
+            refout: false,
+            xorout: 0x0000000000000000,
+            check: 0x6c40df5f0b497347,
+            residue: 0x0000000000000000,
+        };
+
+        let algs_to_test = [&CRC_64_ECMA_182, &CRC_64_ECMA_182_REFLEX];
+
+        for alg in algs_to_test {
+            for data in data {
+                let crc_slice16 = Crc::<Slice16<u64>>::new(alg);
+                let crc_nolookup = Crc::<NoTable<u64>>::new(alg);
+                let expected = Crc::<Bytewise<u64>>::new(alg).checksum(data.as_bytes());
+
+                // Check that doing all at once works as expected
+                assert_eq!(crc_slice16.checksum(data.as_bytes()), expected);
+                assert_eq!(crc_nolookup.checksum(data.as_bytes()), expected);
+
+                let mut digest = crc_slice16.digest();
+                digest.update(data.as_bytes());
+                assert_eq!(digest.finalize(), expected);
+
+                let mut digest = crc_nolookup.digest();
+                digest.update(data.as_bytes());
+                assert_eq!(digest.finalize(), expected);
+
+                // Check that we didn't break updating from multiple sources
+                if data.len() > 2 {
+                    let data = data.as_bytes();
+                    let data1 = &data[..data.len() / 2];
+                    let data2 = &data[data.len() / 2..];
+                    let mut digest = crc_slice16.digest();
+                    digest.update(data1);
+                    digest.update(data2);
+                    assert_eq!(digest.finalize(), expected);
+                    let mut digest = crc_nolookup.digest();
+                    digest.update(data1);
+                    digest.update(data2);
+                    assert_eq!(digest.finalize(), expected);
+                }
+            }
+        }
     }
 }

--- a/src/crc64/bytewise.rs
+++ b/src/crc64/bytewise.rs
@@ -1,0 +1,49 @@
+use crate::table::crc64_table;
+use crate::{Algorithm, Bytewise, Crc, Digest};
+
+use super::{finalize, init, update_bytewise};
+
+impl Crc<Bytewise<u64>> {
+    pub const fn new(algorithm: &'static Algorithm<u64>) -> Self {
+        let table = crc64_table(algorithm.width, algorithm.poly, algorithm.refin);
+        Self { algorithm, table }
+    }
+
+    pub const fn checksum(&self, bytes: &[u8]) -> u64 {
+        let mut crc = init(self.algorithm, self.algorithm.init);
+        crc = self.update(crc, bytes);
+        finalize(self.algorithm, crc)
+    }
+
+    const fn update(&self, crc: u64, bytes: &[u8]) -> u64 {
+        update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
+    }
+
+    pub const fn digest(&self) -> Digest<Bytewise<u64>> {
+        self.digest_with_initial(self.algorithm.init)
+    }
+
+    /// Construct a `Digest` with a given initial value.
+    ///
+    /// This overrides the initial value specified by the algorithm.
+    /// The effects of the algorithm's properties `refin` and `width`
+    /// are applied to the custom initial value.
+    pub const fn digest_with_initial(&self, initial: u64) -> Digest<Bytewise<u64>> {
+        let value = init(self.algorithm, initial);
+        Digest::new(self, value)
+    }
+}
+
+impl<'a> Digest<'a, Bytewise<u64>> {
+    const fn new(crc: &'a Crc<Bytewise<u64>>, value: u64) -> Self {
+        Digest { crc, value }
+    }
+
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.value = self.crc.update(self.value, bytes);
+    }
+
+    pub const fn finalize(self) -> u64 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}

--- a/src/crc64/default.rs
+++ b/src/crc64/default.rs
@@ -1,0 +1,49 @@
+use crate::table::crc64_table;
+use crate::{Algorithm, Crc, Digest};
+
+use super::{finalize, init, update_bytewise};
+
+impl Crc<u64> {
+    pub const fn new(algorithm: &'static Algorithm<u64>) -> Self {
+        let table = crc64_table(algorithm.width, algorithm.poly, algorithm.refin);
+        Self { algorithm, table }
+    }
+
+    pub const fn checksum(&self, bytes: &[u8]) -> u64 {
+        let mut crc = init(self.algorithm, self.algorithm.init);
+        crc = self.update(crc, bytes);
+        finalize(self.algorithm, crc)
+    }
+
+    const fn update(&self, crc: u64, bytes: &[u8]) -> u64 {
+        update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
+    }
+
+    pub const fn digest(&self) -> Digest<u64> {
+        self.digest_with_initial(self.algorithm.init)
+    }
+
+    /// Construct a `Digest` with a given initial value.
+    ///
+    /// This overrides the initial value specified by the algorithm.
+    /// The effects of the algorithm's properties `refin` and `width`
+    /// are applied to the custom initial value.
+    pub const fn digest_with_initial(&self, initial: u64) -> Digest<u64> {
+        let value = init(self.algorithm, initial);
+        Digest::new(self, value)
+    }
+}
+
+impl<'a> Digest<'a, u64> {
+    const fn new(crc: &'a Crc<u64>, value: u64) -> Self {
+        Digest { crc, value }
+    }
+
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.value = self.crc.update(self.value, bytes);
+    }
+
+    pub const fn finalize(self) -> u64 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}

--- a/src/crc64/nolookup.rs
+++ b/src/crc64/nolookup.rs
@@ -1,0 +1,50 @@
+use crate::{Algorithm, Crc, Digest, NoTable};
+
+use super::{finalize, init, update_nolookup};
+
+impl Crc<NoTable<u64>> {
+    pub const fn new(algorithm: &'static Algorithm<u64>) -> Self {
+        Self {
+            algorithm,
+            table: (),
+        }
+    }
+
+    pub const fn checksum(&self, bytes: &[u8]) -> u64 {
+        let mut crc = init(self.algorithm, self.algorithm.init);
+        crc = self.update(crc, bytes);
+        finalize(self.algorithm, crc)
+    }
+
+    const fn update(&self, crc: u64, bytes: &[u8]) -> u64 {
+        update_nolookup(crc, self.algorithm, bytes)
+    }
+
+    pub const fn digest(&self) -> Digest<NoTable<u64>> {
+        self.digest_with_initial(self.algorithm.init)
+    }
+
+    /// Construct a `Digest` with a given initial value.
+    ///
+    /// This overrides the initial value specified by the algorithm.
+    /// The effects of the algorithm's properties `refin` and `width`
+    /// are applied to the custom initial value.
+    pub const fn digest_with_initial(&self, initial: u64) -> Digest<NoTable<u64>> {
+        let value = init(self.algorithm, initial);
+        Digest::new(self, value)
+    }
+}
+
+impl<'a> Digest<'a, NoTable<u64>> {
+    const fn new(crc: &'a Crc<NoTable<u64>>, value: u64) -> Self {
+        Digest { crc, value }
+    }
+
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.value = self.crc.update(self.value, bytes);
+    }
+
+    pub const fn finalize(self) -> u64 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}

--- a/src/crc64/slice16.rs
+++ b/src/crc64/slice16.rs
@@ -1,0 +1,49 @@
+use crate::table::crc64_table_slice_16;
+use crate::{Algorithm, Crc, Digest, Slice16};
+
+use super::{finalize, init, update_slice16};
+
+impl Crc<Slice16<u64>> {
+    pub const fn new(algorithm: &'static Algorithm<u64>) -> Self {
+        let table = crc64_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
+        Self { algorithm, table }
+    }
+
+    pub const fn checksum(&self, bytes: &[u8]) -> u64 {
+        let mut crc = init(self.algorithm, self.algorithm.init);
+        crc = self.update(crc, bytes);
+        finalize(self.algorithm, crc)
+    }
+
+    const fn update(&self, crc: u64, bytes: &[u8]) -> u64 {
+        update_slice16(crc, self.algorithm.refin, &self.table, bytes)
+    }
+
+    pub const fn digest(&self) -> Digest<Slice16<u64>> {
+        self.digest_with_initial(self.algorithm.init)
+    }
+
+    /// Construct a `Digest` with a given initial value.
+    ///
+    /// This overrides the initial value specified by the algorithm.
+    /// The effects of the algorithm's properties `refin` and `width`
+    /// are applied to the custom initial value.
+    pub const fn digest_with_initial(&self, initial: u64) -> Digest<Slice16<u64>> {
+        let value = init(self.algorithm, initial);
+        Digest::new(self, value)
+    }
+}
+
+impl<'a> Digest<'a, Slice16<u64>> {
+    const fn new(crc: &'a Crc<Slice16<u64>>, value: u64) -> Self {
+        Digest { crc, value }
+    }
+
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.value = self.crc.update(self.value, bytes);
+    }
+
+    pub const fn finalize(self) -> u64 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! digest.update(b"123456789");
 //! assert_eq!(digest.finalize(), 0xaee7);
 //! ```
-#![no_std]
+//#![no_std]
 #![forbid(unsafe_code)]
 
 pub use crc_catalog::*;

--- a/src/table.rs
+++ b/src/table.rs
@@ -101,6 +101,38 @@ pub(crate) const fn crc64_table(width: u8, poly: u64, reflect: bool) -> [u64; 25
     table
 }
 
+pub(crate) const fn crc64_table_slice_16(width: u8, poly: u64, reflect: bool) -> [[u64; 256]; 16] {
+    let poly = if reflect {
+        let poly = poly.reverse_bits();
+        poly >> (64u8 - width)
+    } else {
+        poly << (64u8 - width)
+    };
+
+    let mut table = [[0u64; 256]; 16];
+    let mut i = 0;
+    while i < 256 {
+        table[0][i] = crc64(poly, reflect, i as u64);
+        i += 1;
+    }
+
+    let mut i = 0;
+    while i < 256 {
+        let mut e = 1;
+        while e < 16 {
+            let one_lower = table[e - 1][i];
+            if reflect {
+                table[e][i] = (one_lower >> 8) ^ table[0][(one_lower & 0xFF) as usize];
+            } else {
+                table[e][i] = (one_lower << 8) ^ table[0][((one_lower >> 56) & 0xFF) as usize];
+            }
+            e += 1;
+        }
+        i += 1;
+    }
+    table
+}
+
 pub(crate) const fn crc128_table(width: u8, poly: u128, reflect: bool) -> [u128; 256] {
     let poly = if reflect {
         let poly = poly.reverse_bits();


### PR DESCRIPTION
Got around to implement slice16 and no-table flavours for Crc<u64> 

Benches:

```
crc64/default           time:   [29.969 µs 30.022 µs 30.082 µs]
                        thrpt:  [519.41 MiB/s 520.45 MiB/s 521.37 MiB/s]

crc64/nolookup          time:   [111.28 µs 111.51 µs 111.72 µs]
                        thrpt:  [139.86 MiB/s 140.12 MiB/s 140.41 MiB/s]

crc64/bytewise          time:   [29.864 µs 29.934 µs 30.004 µs]
                        thrpt:  [520.77 MiB/s 521.98 MiB/s 523.21 MiB/s]

crc64/slice16           time:   [5.1544 µs 5.1681 µs 5.1839 µs]
                        thrpt:  [2.9435 GiB/s 2.9525 GiB/s 2.9603 GiB/s]

```