### PR TITLE
Add crc128 slice-by-16 and no-table implementations

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -13,6 +13,9 @@ pub const ECMA_SLICE16: Crc<Slice16<u64>> = Crc::<Slice16<u64>>::new(&CRC_64_ECM
 pub const ECMA_BYTEWISE: Crc<Bytewise<u64>> = Crc::<Bytewise<u64>>::new(&CRC_64_ECMA_182);
 pub const ECMA_NOLOOKUP: Crc<NoTable<u64>> = Crc::<NoTable<u64>>::new(&CRC_64_ECMA_182);
 pub const DARC: Crc<u128> = Crc::<u128>::new(&CRC_82_DARC);
+pub const DARC_SLICE16: Crc<Slice16<u128>> = Crc::<Slice16<u128>>::new(&CRC_82_DARC);
+pub const DARC_BYTEWISE: Crc<Bytewise<u128>> = Crc::<Bytewise<u128>>::new(&CRC_82_DARC);
+pub const DARC_NOLOOKUP: Crc<NoTable<u128>> = Crc::<NoTable<u128>>::new(&CRC_82_DARC);
 
 static KB: usize = 1024;
 
@@ -55,11 +58,23 @@ fn checksum(c: &mut Criterion) {
             b.iter(|| ECMA_SLICE16.checksum(black_box(&bytes)))
         });
 
+    c.benchmark_group("crc82")
+        .throughput(Throughput::Bytes(size as u64))
+        .bench_function("default", |b| b.iter(|| DARC.checksum(black_box(&bytes))))
+        .bench_function("nolookup", |b| {
+            b.iter(|| DARC_NOLOOKUP.checksum(black_box(&bytes)))
+        })
+        .bench_function("bytewise", |b| {
+            b.iter(|| DARC_BYTEWISE.checksum(black_box(&bytes)))
+        })
+        .bench_function("slice16", |b| {
+            b.iter(|| DARC_SLICE16.checksum(black_box(&bytes)))
+        });
+
     c.benchmark_group("checksum")
         .bench_function("crc8", |b| b.iter(|| BLUETOOTH.checksum(black_box(&bytes))))
         .bench_function("crc16", |b| b.iter(|| X25.checksum(black_box(&bytes))))
-        .bench_function("crc40", |b| b.iter(|| GSM_40.checksum(black_box(&bytes))))
-        .bench_function("crc82", |b| b.iter(|| DARC.checksum(black_box(&bytes))));
+        .bench_function("crc40", |b| b.iter(|| GSM_40.checksum(black_box(&bytes))));
 }
 
 criterion_group!(checksum_benches, checksum);

--- a/src/crc128.rs
+++ b/src/crc128.rs
@@ -1,83 +1,237 @@
-use super::{Algorithm, Crc, Digest};
-use crate::table::crc128_table;
+use crc_catalog::Algorithm;
 
-impl Crc<u128> {
-    pub const fn new(algorithm: &'static Algorithm<u128>) -> Self {
-        let table = crc128_table(algorithm.width, algorithm.poly, algorithm.refin);
-        Self { algorithm, table }
-    }
+use crate::util::crc128;
 
-    pub const fn checksum(&self, bytes: &[u8]) -> u128 {
-        let mut crc = self.init(self.algorithm.init);
-        crc = self.update(crc, bytes);
-        self.finalize(crc)
-    }
+mod bytewise;
+mod default;
+mod nolookup;
+mod slice16;
 
-    const fn init(&self, initial: u128) -> u128 {
-        if self.algorithm.refin {
-            initial.reverse_bits() >> (128u8 - self.algorithm.width)
-        } else {
-            initial << (128u8 - self.algorithm.width)
-        }
-    }
-
-    const fn table_entry(&self, index: u128) -> u128 {
-        self.table[(index & 0xFF) as usize]
-    }
-
-    const fn update(&self, mut crc: u128, bytes: &[u8]) -> u128 {
-        let mut i = 0;
-        if self.algorithm.refin {
-            while i < bytes.len() {
-                let table_index = crc ^ bytes[i] as u128;
-                crc = self.table_entry(table_index) ^ (crc >> 8);
-                i += 1;
-            }
-        } else {
-            while i < bytes.len() {
-                let table_index = (crc >> 120) ^ bytes[i] as u128;
-                crc = self.table_entry(table_index) ^ (crc << 8);
-                i += 1;
-            }
-        }
-        crc
-    }
-
-    const fn finalize(&self, mut crc: u128) -> u128 {
-        if self.algorithm.refin ^ self.algorithm.refout {
-            crc = crc.reverse_bits();
-        }
-        if !self.algorithm.refout {
-            crc >>= 128u8 - self.algorithm.width;
-        }
-        crc ^ self.algorithm.xorout
-    }
-
-    pub const fn digest(&self) -> Digest<u128> {
-        self.digest_with_initial(self.algorithm.init)
-    }
-
-    /// Construct a `Digest` with a given initial value.
-    ///
-    /// This overrides the initial value specified by the algorithm.
-    /// The effects of the algorithm's properties `refin` and `width`
-    /// are applied to the custom initial value.
-    pub const fn digest_with_initial(&self, initial: u128) -> Digest<u128> {
-        let value = self.init(initial);
-        Digest::new(self, value)
+const fn init(algorithm: &Algorithm<u128>, initial: u128) -> u128 {
+    if algorithm.refin {
+        initial.reverse_bits() >> (128u8 - algorithm.width)
+    } else {
+        initial << (128u8 - algorithm.width)
     }
 }
 
-impl<'a> Digest<'a, u128> {
-    const fn new(crc: &'a Crc<u128>, value: u128) -> Self {
-        Digest { crc, value }
+const fn finalize(algorithm: &Algorithm<u128>, mut crc: u128) -> u128 {
+    if algorithm.refin ^ algorithm.refout {
+        crc = crc.reverse_bits();
     }
-
-    pub fn update(&mut self, bytes: &[u8]) {
-        self.value = self.crc.update(self.value, bytes);
+    if !algorithm.refout {
+        crc >>= 128u8 - algorithm.width;
     }
+    crc ^ algorithm.xorout
+}
 
-    pub const fn finalize(self) -> u128 {
-        self.crc.finalize(self.value)
+const fn update_nolookup(mut crc: u128, algorithm: &Algorithm<u128>, bytes: &[u8]) -> u128 {
+    let poly = if algorithm.refin {
+        let poly = algorithm.poly.reverse_bits();
+        poly >> (128u8 - algorithm.width)
+    } else {
+        algorithm.poly << (128u8 - algorithm.width)
+    };
+
+    let mut i = 0;
+    if algorithm.refin {
+        while i < bytes.len() {
+            let to_crc = (crc ^ bytes[i] as u128) & 0xFF;
+            crc = crc128(poly, algorithm.refin, to_crc) ^ (crc >> 8);
+            i += 1;
+        }
+    } else {
+        while i < bytes.len() {
+            let to_crc = ((crc >> 120) ^ bytes[i] as u128) & 0xFF;
+            crc = crc128(poly, algorithm.refin, to_crc) ^ (crc << 8);
+            i += 1;
+        }
+    }
+    crc
+}
+
+const fn update_bytewise(mut crc: u128, reflect: bool, table: &[u128; 256], bytes: &[u8]) -> u128 {
+    let mut i = 0;
+    if reflect {
+        while i < bytes.len() {
+            let table_index = ((crc ^ bytes[i] as u128) & 0xFF) as usize;
+            crc = table[table_index] ^ (crc >> 8);
+            i += 1;
+        }
+    } else {
+        while i < bytes.len() {
+            let table_index = (((crc >> 120) ^ bytes[i] as u128) & 0xFF) as usize;
+            crc = table[table_index] ^ (crc << 8);
+            i += 1;
+        }
+    }
+    crc
+}
+
+const fn update_slice16(
+    mut crc: u128,
+    reflect: bool,
+    table: &[[u128; 256]; 16],
+    bytes: &[u8],
+) -> u128 {
+    let mut i = 0;
+    let len = bytes.len();
+    if reflect {
+        while i + 16 < len {
+            let current0 = bytes[i] ^ crc as u8;
+            let current1 = bytes[i + 1] ^ (crc >> 8) as u8;
+            let current2 = bytes[i + 2] ^ (crc >> 16) as u8;
+            let current3 = bytes[i + 3] ^ (crc >> 24) as u8;
+            let current4 = bytes[i + 4] ^ (crc >> 32) as u8;
+            let current5 = bytes[i + 5] ^ (crc >> 40) as u8;
+            let current6 = bytes[i + 6] ^ (crc >> 48) as u8;
+            let current7 = bytes[i + 7] ^ (crc >> 56) as u8;
+            let current8 = bytes[i + 8] ^ (crc >> 64) as u8;
+            let current9 = bytes[i + 9] ^ (crc >> 72) as u8;
+            let current10 = bytes[i + 10] ^ (crc >> 80) as u8;
+            let current11 = bytes[i + 11] ^ (crc >> 88) as u8;
+            let current12 = bytes[i + 12] ^ (crc >> 96) as u8;
+            let current13 = bytes[i + 13] ^ (crc >> 104) as u8;
+            let current14 = bytes[i + 14] ^ (crc >> 112) as u8;
+            let current15 = bytes[i + 15] ^ (crc >> 120) as u8;
+
+            crc = table[15][current0 as usize]
+                ^ table[14][current1 as usize]
+                ^ table[13][current2 as usize]
+                ^ table[12][current3 as usize]
+                ^ table[11][current4 as usize]
+                ^ table[10][current5 as usize]
+                ^ table[9][current6 as usize]
+                ^ table[8][current7 as usize]
+                ^ table[7][current8 as usize]
+                ^ table[6][current9 as usize]
+                ^ table[5][current10 as usize]
+                ^ table[4][current11 as usize]
+                ^ table[3][current12 as usize]
+                ^ table[2][current13 as usize]
+                ^ table[1][current14 as usize]
+                ^ table[0][current15 as usize];
+
+            i += 16;
+        }
+
+        while i < len {
+            let table_index = ((crc ^ bytes[i] as u128) & 0xFF) as usize;
+            crc = table[0][table_index] ^ (crc >> 8);
+            i += 1;
+        }
+    } else {
+        while i + 16 < len {
+            let current0 = bytes[i] ^ (crc >> 120) as u8;
+            let current1 = bytes[i + 1] ^ (crc >> 112) as u8;
+            let current2 = bytes[i + 2] ^ (crc >> 104) as u8;
+            let current3 = bytes[i + 3] ^ (crc >> 96) as u8;
+            let current4 = bytes[i + 4] ^ (crc >> 88) as u8;
+            let current5 = bytes[i + 5] ^ (crc >> 80) as u8;
+            let current6 = bytes[i + 6] ^ (crc >> 72) as u8;
+            let current7 = bytes[i + 7] ^ (crc >> 64) as u8;
+            let current8 = bytes[i + 8] ^ (crc >> 56) as u8;
+            let current9 = bytes[i + 9] ^ (crc >> 48) as u8;
+            let current10 = bytes[i + 10] ^ (crc >> 40) as u8;
+            let current11 = bytes[i + 11] ^ (crc >> 32) as u8;
+            let current12 = bytes[i + 12] ^ (crc >> 24) as u8;
+            let current13 = bytes[i + 13] ^ (crc >> 16) as u8;
+            let current14 = bytes[i + 14] ^ (crc >> 8) as u8;
+            let current15 = bytes[i + 15] ^ crc as u8;
+
+            crc = table[15][current0 as usize]
+                ^ table[14][current1 as usize]
+                ^ table[13][current2 as usize]
+                ^ table[12][current3 as usize]
+                ^ table[11][current4 as usize]
+                ^ table[10][current5 as usize]
+                ^ table[9][current6 as usize]
+                ^ table[8][current7 as usize]
+                ^ table[7][current8 as usize]
+                ^ table[6][current9 as usize]
+                ^ table[5][current10 as usize]
+                ^ table[4][current11 as usize]
+                ^ table[3][current12 as usize]
+                ^ table[2][current13 as usize]
+                ^ table[1][current14 as usize]
+                ^ table[0][current15 as usize];
+
+            i += 16;
+        }
+
+        while i < len {
+            let table_index = (((crc >> 120) ^ bytes[i] as u128) & 0xFF) as usize;
+            crc = table[0][table_index] ^ (crc << 8);
+            i += 1;
+        }
+    }
+    crc
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{Bytewise, Crc, NoTable, Slice16};
+    use crc_catalog::{Algorithm, CRC_82_DARC};
+
+    /// Test this opitimized version against the well known implementation to ensure correctness
+    #[test]
+    fn correctness() {
+        let data: &[&str] = &[
+        "",
+        "1",
+        "1234",
+        "123456789",
+        "0123456789ABCDE",
+        "01234567890ABCDEFGHIJK",
+        "01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK",
+    ];
+
+        pub const CRC_82_DARC_NONREFLEX: Algorithm<u128> = Algorithm {
+            width: 82,
+            poly: 0x0308c0111011401440411,
+            init: 0x000000000000000000000,
+            refin: false,
+            refout: true,
+            xorout: 0x000000000000000000000,
+            check: 0x09ea83f625023801fd612,
+            residue: 0x000000000000000000000,
+        };
+
+        let algs_to_test = [&CRC_82_DARC, &CRC_82_DARC_NONREFLEX];
+
+        for alg in algs_to_test {
+            for data in data {
+                let crc_slice16 = Crc::<Slice16<u128>>::new(alg);
+                let crc_nolookup = Crc::<NoTable<u128>>::new(alg);
+                let expected = Crc::<Bytewise<u128>>::new(alg).checksum(data.as_bytes());
+
+                // Check that doing all at once works as expected
+                assert_eq!(crc_slice16.checksum(data.as_bytes()), expected);
+                assert_eq!(crc_nolookup.checksum(data.as_bytes()), expected);
+
+                let mut digest = crc_slice16.digest();
+                digest.update(data.as_bytes());
+                assert_eq!(digest.finalize(), expected);
+
+                let mut digest = crc_nolookup.digest();
+                digest.update(data.as_bytes());
+                assert_eq!(digest.finalize(), expected);
+
+                // Check that we didn't break updating from multiple sources
+                if data.len() > 2 {
+                    let data = data.as_bytes();
+                    let data1 = &data[..data.len() / 2];
+                    let data2 = &data[data.len() / 2..];
+                    let mut digest = crc_slice16.digest();
+                    digest.update(data1);
+                    digest.update(data2);
+                    assert_eq!(digest.finalize(), expected);
+                    let mut digest = crc_nolookup.digest();
+                    digest.update(data1);
+                    digest.update(data2);
+                    assert_eq!(digest.finalize(), expected);
+                }
+            }
+        }
     }
 }

--- a/src/crc128/bytewise.rs
+++ b/src/crc128/bytewise.rs
@@ -1,0 +1,49 @@
+use crate::table::crc128_table;
+use crate::{Algorithm, Bytewise, Crc, Digest};
+
+use super::{finalize, init, update_bytewise};
+
+impl Crc<Bytewise<u128>> {
+    pub const fn new(algorithm: &'static Algorithm<u128>) -> Self {
+        let table = crc128_table(algorithm.width, algorithm.poly, algorithm.refin);
+        Self { algorithm, table }
+    }
+
+    pub const fn checksum(&self, bytes: &[u8]) -> u128 {
+        let mut crc = init(self.algorithm, self.algorithm.init);
+        crc = self.update(crc, bytes);
+        finalize(self.algorithm, crc)
+    }
+
+    const fn update(&self, crc: u128, bytes: &[u8]) -> u128 {
+        update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
+    }
+
+    pub const fn digest(&self) -> Digest<Bytewise<u128>> {
+        self.digest_with_initial(self.algorithm.init)
+    }
+
+    /// Construct a `Digest` with a given initial value.
+    ///
+    /// This overrides the initial value specified by the algorithm.
+    /// The effects of the algorithm's properties `refin` and `width`
+    /// are applied to the custom initial value.
+    pub const fn digest_with_initial(&self, initial: u128) -> Digest<Bytewise<u128>> {
+        let value = init(self.algorithm, initial);
+        Digest::new(self, value)
+    }
+}
+
+impl<'a> Digest<'a, Bytewise<u128>> {
+    const fn new(crc: &'a Crc<Bytewise<u128>>, value: u128) -> Self {
+        Digest { crc, value }
+    }
+
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.value = self.crc.update(self.value, bytes);
+    }
+
+    pub const fn finalize(self) -> u128 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}

--- a/src/crc128/default.rs
+++ b/src/crc128/default.rs
@@ -1,0 +1,49 @@
+use crate::table::crc128_table;
+use crate::{Algorithm, Crc, Digest};
+
+use super::{finalize, init, update_bytewise};
+
+impl Crc<u128> {
+    pub const fn new(algorithm: &'static Algorithm<u128>) -> Self {
+        let table = crc128_table(algorithm.width, algorithm.poly, algorithm.refin);
+        Self { algorithm, table }
+    }
+
+    pub const fn checksum(&self, bytes: &[u8]) -> u128 {
+        let mut crc = init(self.algorithm, self.algorithm.init);
+        crc = self.update(crc, bytes);
+        finalize(self.algorithm, crc)
+    }
+
+    const fn update(&self, crc: u128, bytes: &[u8]) -> u128 {
+        update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
+    }
+
+    pub const fn digest(&self) -> Digest<u128> {
+        self.digest_with_initial(self.algorithm.init)
+    }
+
+    /// Construct a `Digest` with a given initial value.
+    ///
+    /// This overrides the initial value specified by the algorithm.
+    /// The effects of the algorithm's properties `refin` and `width`
+    /// are applied to the custom initial value.
+    pub const fn digest_with_initial(&self, initial: u128) -> Digest<u128> {
+        let value = init(self.algorithm, initial);
+        Digest::new(self, value)
+    }
+}
+
+impl<'a> Digest<'a, u128> {
+    const fn new(crc: &'a Crc<u128>, value: u128) -> Self {
+        Digest { crc, value }
+    }
+
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.value = self.crc.update(self.value, bytes);
+    }
+
+    pub const fn finalize(self) -> u128 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}

--- a/src/crc128/nolookup.rs
+++ b/src/crc128/nolookup.rs
@@ -1,0 +1,50 @@
+use crate::{Algorithm, Crc, Digest, NoTable};
+
+use super::{finalize, init, update_nolookup};
+
+impl Crc<NoTable<u128>> {
+    pub const fn new(algorithm: &'static Algorithm<u128>) -> Self {
+        Self {
+            algorithm,
+            table: (),
+        }
+    }
+
+    pub const fn checksum(&self, bytes: &[u8]) -> u128 {
+        let mut crc = init(self.algorithm, self.algorithm.init);
+        crc = self.update(crc, bytes);
+        finalize(self.algorithm, crc)
+    }
+
+    const fn update(&self, crc: u128, bytes: &[u8]) -> u128 {
+        update_nolookup(crc, self.algorithm, bytes)
+    }
+
+    pub const fn digest(&self) -> Digest<NoTable<u128>> {
+        self.digest_with_initial(self.algorithm.init)
+    }
+
+    /// Construct a `Digest` with a given initial value.
+    ///
+    /// This overrides the initial value specified by the algorithm.
+    /// The effects of the algorithm's properties `refin` and `width`
+    /// are applied to the custom initial value.
+    pub const fn digest_with_initial(&self, initial: u128) -> Digest<NoTable<u128>> {
+        let value = init(self.algorithm, initial);
+        Digest::new(self, value)
+    }
+}
+
+impl<'a> Digest<'a, NoTable<u128>> {
+    const fn new(crc: &'a Crc<NoTable<u128>>, value: u128) -> Self {
+        Digest { crc, value }
+    }
+
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.value = self.crc.update(self.value, bytes);
+    }
+
+    pub const fn finalize(self) -> u128 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}

--- a/src/crc128/slice16.rs
+++ b/src/crc128/slice16.rs
@@ -1,0 +1,49 @@
+use crate::table::crc128_table_slice16;
+use crate::{Algorithm, Crc, Digest, Slice16};
+
+use super::{finalize, init, update_slice16};
+
+impl Crc<Slice16<u128>> {
+    pub const fn new(algorithm: &'static Algorithm<u128>) -> Self {
+        let table = crc128_table_slice16(algorithm.width, algorithm.poly, algorithm.refin);
+        Self { algorithm, table }
+    }
+
+    pub const fn checksum(&self, bytes: &[u8]) -> u128 {
+        let mut crc = init(self.algorithm, self.algorithm.init);
+        crc = self.update(crc, bytes);
+        finalize(self.algorithm, crc)
+    }
+
+    const fn update(&self, crc: u128, bytes: &[u8]) -> u128 {
+        update_slice16(crc, self.algorithm.refin, &self.table, bytes)
+    }
+
+    pub const fn digest(&self) -> Digest<Slice16<u128>> {
+        self.digest_with_initial(self.algorithm.init)
+    }
+
+    /// Construct a `Digest` with a given initial value.
+    ///
+    /// This overrides the initial value specified by the algorithm.
+    /// The effects of the algorithm's properties `refin` and `width`
+    /// are applied to the custom initial value.
+    pub const fn digest_with_initial(&self, initial: u128) -> Digest<Slice16<u128>> {
+        let value = init(self.algorithm, initial);
+        Digest::new(self, value)
+    }
+}
+
+impl<'a> Digest<'a, Slice16<u128>> {
+    const fn new(crc: &'a Crc<Slice16<u128>>, value: u128) -> Self {
+        Digest { crc, value }
+    }
+
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.value = self.crc.update(self.value, bytes);
+    }
+
+    pub const fn finalize(self) -> u128 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}


### PR DESCRIPTION
This one is interesting, the speedup is way smaller because of the 128bit (=16 Bytes) wide crc. The speedup is still there but it's debate-able if slice-by-16 or bytewise algorithm should be the default. The lookup table for the slice-by-16 alg is 64 kB large for u128 entries.  

Benches: 

```
crc82/default           time:   [35.621 µs 35.642 µs 35.667 µs]
                        thrpt:  [438.08 MiB/s 438.38 MiB/s 438.64 MiB/s]

crc82/nolookup          time:   [171.31 µs 171.51 µs 171.75 µs]
                        thrpt:  [90.974 MiB/s 91.102 MiB/s 91.206 MiB/s]

crc82/bytewise          time:   [35.318 µs 35.323 µs 35.329 µs]
                        thrpt:  [442.28 MiB/s 442.34 MiB/s 442.41 MiB/s]

crc82/slice16           time:   [25.078 µs 25.084 µs 25.090 µs]
                        thrpt:  [622.75 MiB/s 622.90 MiB/s 623.05 MiB/s]

```