### PR TITLE
Replace unmaintained actions-rs/cargo action in CI workflow

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -20,14 +20,8 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo fmt --all -- --check
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -43,12 +37,8 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
+      - run: cargo check
+      - run: cargo build
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -63,6 +53,4 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: cargo test


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/mrhooray/crc-rs/actions/runs/4093752674:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions-rs/toolchain@v1, __actions-rs/cargo@v1__. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of some of those warnings the occurrences of `actions-rs/cargo` are replaced by direct invocations of `cargo`.