### PR TITLE
Add crc16 slice-by-16 and no-table implementations

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,6 +3,9 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughpu
 
 pub const BLUETOOTH: Crc<u8> = Crc::<u8>::new(&CRC_8_BLUETOOTH);
 pub const X25: Crc<u16> = Crc::<u16>::new(&CRC_16_IBM_SDLC);
+pub const X25_SLICE16: Crc<Slice16<u16>> = Crc::<Slice16<u16>>::new(&CRC_16_IBM_SDLC);
+pub const X25_BYTEWISE: Crc<Bytewise<u16>> = Crc::<Bytewise<u16>>::new(&CRC_16_IBM_SDLC);
+pub const X25_NOLOOKUP: Crc<NoTable<u16>> = Crc::<NoTable<u16>>::new(&CRC_16_IBM_SDLC);
 pub const ISCSI: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 pub const ISCSI_SLICE16: Crc<Slice16<u32>> = Crc::<Slice16<u32>>::new(&CRC_32_ISCSI);
 pub const ISCSI_BYTEWISE: Crc<Bytewise<u32>> = Crc::<Bytewise<u32>>::new(&CRC_32_ISCSI);
@@ -31,6 +34,19 @@ fn checksum(c: &mut Criterion) {
     c.benchmark_group("baseline")
         .throughput(Throughput::Bytes(size as u64))
         .bench_function("baseline", |b| b.iter(|| baseline(black_box(&bytes))));
+
+    c.benchmark_group("crc16")
+        .throughput(Throughput::Bytes(size as u64))
+        .bench_function("default", |b| b.iter(|| X25.checksum(black_box(&bytes))))
+        .bench_function("nolookup", |b| {
+            b.iter(|| X25_NOLOOKUP.checksum(black_box(&bytes)))
+        })
+        .bench_function("bytewise", |b| {
+            b.iter(|| X25_BYTEWISE.checksum(black_box(&bytes)))
+        })
+        .bench_function("slice16", |b| {
+            b.iter(|| X25_SLICE16.checksum(black_box(&bytes)))
+        });
 
     c.benchmark_group("crc32")
         .throughput(Throughput::Bytes(size as u64))

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -1,83 +1,208 @@
-use super::{Algorithm, Crc, Digest};
-use crate::table::crc16_table;
+use crate::util::crc16;
+use crc_catalog::Algorithm;
 
-impl Crc<u16> {
-    pub const fn new(algorithm: &'static Algorithm<u16>) -> Self {
-        let table = crc16_table(algorithm.width, algorithm.poly, algorithm.refin);
-        Self { algorithm, table }
-    }
+mod bytewise;
+mod default;
+mod nolookup;
+mod slice16;
 
-    pub const fn checksum(&self, bytes: &[u8]) -> u16 {
-        let mut crc = self.init(self.algorithm.init);
-        crc = self.update(crc, bytes);
-        self.finalize(crc)
-    }
-
-    const fn init(&self, initial: u16) -> u16 {
-        if self.algorithm.refin {
-            initial.reverse_bits() >> (16u8 - self.algorithm.width)
-        } else {
-            initial << (16u8 - self.algorithm.width)
-        }
-    }
-
-    const fn table_entry(&self, index: u16) -> u16 {
-        self.table[(index & 0xFF) as usize]
-    }
-
-    const fn update(&self, mut crc: u16, bytes: &[u8]) -> u16 {
-        let mut i = 0;
-        if self.algorithm.refin {
-            while i < bytes.len() {
-                let table_index = crc ^ bytes[i] as u16;
-                crc = self.table_entry(table_index) ^ (crc >> 8);
-                i += 1;
-            }
-        } else {
-            while i < bytes.len() {
-                let table_index = (crc >> 8) ^ bytes[i] as u16;
-                crc = self.table_entry(table_index) ^ (crc << 8);
-                i += 1;
-            }
-        }
-        crc
-    }
-
-    const fn finalize(&self, mut crc: u16) -> u16 {
-        if self.algorithm.refin ^ self.algorithm.refout {
-            crc = crc.reverse_bits();
-        }
-        if !self.algorithm.refout {
-            crc >>= 16u8 - self.algorithm.width;
-        }
-        crc ^ self.algorithm.xorout
-    }
-
-    pub const fn digest(&self) -> Digest<u16> {
-        self.digest_with_initial(self.algorithm.init)
-    }
-
-    /// Construct a `Digest` with a given initial value.
-    ///
-    /// This overrides the initial value specified by the algorithm.
-    /// The effects of the algorithm's properties `refin` and `width`
-    /// are applied to the custom initial value.
-    pub const fn digest_with_initial(&self, initial: u16) -> Digest<u16> {
-        let value = self.init(initial);
-        Digest::new(self, value)
+const fn init(algorithm: &Algorithm<u16>, initial: u16) -> u16 {
+    if algorithm.refin {
+        initial.reverse_bits() >> (16u8 - algorithm.width)
+    } else {
+        initial << (16u8 - algorithm.width)
     }
 }
 
-impl<'a> Digest<'a, u16> {
-    const fn new(crc: &'a Crc<u16>, value: u16) -> Self {
-        Digest { crc, value }
+const fn finalize(algorithm: &Algorithm<u16>, mut crc: u16) -> u16 {
+    if algorithm.refin ^ algorithm.refout {
+        crc = crc.reverse_bits();
     }
-
-    pub fn update(&mut self, bytes: &[u8]) {
-        self.value = self.crc.update(self.value, bytes);
+    if !algorithm.refout {
+        crc >>= 16u8 - algorithm.width;
     }
+    crc ^ algorithm.xorout
+}
 
-    pub const fn finalize(self) -> u16 {
-        self.crc.finalize(self.value)
+const fn update_nolookup(mut crc: u16, algorithm: &Algorithm<u16>, bytes: &[u8]) -> u16 {
+    let poly = if algorithm.refin {
+        let poly = algorithm.poly.reverse_bits();
+        poly >> (16u8 - algorithm.width)
+    } else {
+        algorithm.poly << (16u8 - algorithm.width)
+    };
+
+    let mut i = 0;
+    if algorithm.refin {
+        while i < bytes.len() {
+            let to_crc = (crc ^ bytes[i] as u16) & 0xFF;
+            crc = crc16(poly, algorithm.refin, to_crc) ^ (crc >> 8);
+            i += 1;
+        }
+    } else {
+        while i < bytes.len() {
+            let to_crc = ((crc >> 8) ^ bytes[i] as u16) & 0xFF;
+            crc = crc16(poly, algorithm.refin, to_crc) ^ (crc << 8);
+            i += 1;
+        }
+    }
+    crc
+}
+
+const fn update_bytewise(mut crc: u16, reflect: bool, table: &[u16; 256], bytes: &[u8]) -> u16 {
+    let mut i = 0;
+    if reflect {
+        while i < bytes.len() {
+            let table_index = ((crc ^ bytes[i] as u16) & 0xFF) as usize;
+            crc = table[table_index] ^ (crc >> 8);
+            i += 1;
+        }
+    } else {
+        while i < bytes.len() {
+            let table_index = (((crc >> 8) ^ bytes[i] as u16) & 0xFF) as usize;
+            crc = table[table_index] ^ (crc << 8);
+            i += 1;
+        }
+    }
+    crc
+}
+
+const fn update_slice16(
+    mut crc: u16,
+    reflect: bool,
+    table: &[[u16; 256]; 16],
+    bytes: &[u8],
+) -> u16 {
+    let len = bytes.len();
+    let mut i = 0;
+    if reflect {
+        while i + 16 < len {
+            let current0 = bytes[i] ^ (crc as u8);
+            let current1 = bytes[i + 1] ^ ((crc >> 8) as u8);
+
+            crc = table[0][bytes[i + 15] as usize]
+                ^ table[1][bytes[i + 14] as usize]
+                ^ table[2][bytes[i + 13] as usize]
+                ^ table[3][bytes[i + 12] as usize]
+                ^ table[4][bytes[i + 11] as usize]
+                ^ table[5][bytes[i + 10] as usize]
+                ^ table[6][bytes[i + 9] as usize]
+                ^ table[7][bytes[i + 8] as usize]
+                ^ table[8][bytes[i + 7] as usize]
+                ^ table[9][bytes[i + 6] as usize]
+                ^ table[10][bytes[i + 5] as usize]
+                ^ table[11][bytes[i + 4] as usize]
+                ^ table[12][bytes[i + 3] as usize]
+                ^ table[13][bytes[i + 2] as usize]
+                ^ table[14][current1 as usize]
+                ^ table[15][current0 as usize];
+
+            i += 16;
+        }
+
+        while i < len {
+            let table_index = ((crc ^ bytes[i] as u16) & 0xFF) as usize;
+            crc = table[0][table_index] ^ (crc >> 8);
+            i += 1;
+        }
+    } else {
+        while i + 16 < len {
+            let current0 = bytes[i] ^ ((crc >> 8) as u8);
+            let current1 = bytes[i + 1] ^ (crc as u8);
+
+            crc = table[0][bytes[i + 15] as usize]
+                ^ table[1][bytes[i + 14] as usize]
+                ^ table[2][bytes[i + 13] as usize]
+                ^ table[3][bytes[i + 12] as usize]
+                ^ table[4][bytes[i + 11] as usize]
+                ^ table[5][bytes[i + 10] as usize]
+                ^ table[6][bytes[i + 9] as usize]
+                ^ table[7][bytes[i + 8] as usize]
+                ^ table[8][bytes[i + 7] as usize]
+                ^ table[9][bytes[i + 6] as usize]
+                ^ table[10][bytes[i + 5] as usize]
+                ^ table[11][bytes[i + 4] as usize]
+                ^ table[12][bytes[i + 3] as usize]
+                ^ table[13][bytes[i + 2] as usize]
+                ^ table[14][current1 as usize]
+                ^ table[15][current0 as usize];
+
+            i += 16;
+        }
+
+        while i < len {
+            let table_index = (((crc >> 8) ^ bytes[i] as u16) & 0xFF) as usize;
+            crc = table[0][table_index] ^ (crc << 8);
+            i += 1;
+        }
+    }
+    crc
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{Bytewise, Crc, NoTable, Slice16};
+    use crc_catalog::{Algorithm, CRC_16_IBM_SDLC};
+
+    /// Test this opitimized version against the well known implementation to ensure correctness
+    #[test]
+    fn correctness() {
+        let data: &[&str] = &[
+            "",
+            "1",
+            "1234",
+            "123456789",
+            "0123456789ABCDE",
+            "01234567890ABCDEFGHIJK",
+            "01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK01234567890ABCDEFGHIJK",
+        ];
+
+        pub const CRC_16_IBM_SDLC_NONREFLEX: Algorithm<u16> = Algorithm {
+            width: 16,
+            poly: 0x1021,
+            init: 0xffff,
+            refin: false,
+            refout: true,
+            xorout: 0xffff,
+            check: 0x906e,
+            residue: 0xf0b8,
+        };
+
+        let algs_to_test = [&CRC_16_IBM_SDLC, &CRC_16_IBM_SDLC_NONREFLEX];
+
+        for alg in algs_to_test {
+            for data in data {
+                let crc_slice16 = Crc::<Slice16<u16>>::new(alg);
+                let crc_nolookup = Crc::<NoTable<u16>>::new(alg);
+                let expected = Crc::<Bytewise<u16>>::new(alg).checksum(data.as_bytes());
+
+                // Check that doing all at once works as expected
+                assert_eq!(crc_slice16.checksum(data.as_bytes()), expected);
+                assert_eq!(crc_nolookup.checksum(data.as_bytes()), expected);
+
+                let mut digest = crc_slice16.digest();
+                digest.update(data.as_bytes());
+                assert_eq!(digest.finalize(), expected);
+
+                let mut digest = crc_nolookup.digest();
+                digest.update(data.as_bytes());
+                assert_eq!(digest.finalize(), expected);
+
+                // Check that we didn't break updating from multiple sources
+                if data.len() > 2 {
+                    let data = data.as_bytes();
+                    let data1 = &data[..data.len() / 2];
+                    let data2 = &data[data.len() / 2..];
+                    let mut digest = crc_slice16.digest();
+                    digest.update(data1);
+                    digest.update(data2);
+                    assert_eq!(digest.finalize(), expected);
+                    let mut digest = crc_nolookup.digest();
+                    digest.update(data1);
+                    digest.update(data2);
+                    assert_eq!(digest.finalize(), expected);
+                }
+            }
+        }
     }
 }

--- a/src/crc16/bytewise.rs
+++ b/src/crc16/bytewise.rs
@@ -1,25 +1,24 @@
-use crate::table::crc128_table_slice_16;
-use crate::{Algorithm, Crc, Digest, Slice16};
+use crate::crc16::{finalize, init, update_bytewise};
+use crate::table::crc16_table;
+use crate::{Algorithm, Bytewise, Crc, Digest};
 
-use super::{finalize, init, update_slice16};
-
-impl Crc<Slice16<u128>> {
-    pub const fn new(algorithm: &'static Algorithm<u128>) -> Self {
-        let table = crc128_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
+impl Crc<Bytewise<u16>> {
+    pub const fn new(algorithm: &'static Algorithm<u16>) -> Self {
+        let table = crc16_table(algorithm.width, algorithm.poly, algorithm.refin);
         Self { algorithm, table }
     }
 
-    pub const fn checksum(&self, bytes: &[u8]) -> u128 {
+    pub const fn checksum(&self, bytes: &[u8]) -> u16 {
         let mut crc = init(self.algorithm, self.algorithm.init);
         crc = self.update(crc, bytes);
         finalize(self.algorithm, crc)
     }
 
-    const fn update(&self, crc: u128, bytes: &[u8]) -> u128 {
-        update_slice16(crc, self.algorithm.refin, &self.table, bytes)
+    const fn update(&self, crc: u16, bytes: &[u8]) -> u16 {
+        update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
     }
 
-    pub const fn digest(&self) -> Digest<Slice16<u128>> {
+    pub const fn digest(&self) -> Digest<Bytewise<u16>> {
         self.digest_with_initial(self.algorithm.init)
     }
 
@@ -28,14 +27,14 @@ impl Crc<Slice16<u128>> {
     /// This overrides the initial value specified by the algorithm.
     /// The effects of the algorithm's properties `refin` and `width`
     /// are applied to the custom initial value.
-    pub const fn digest_with_initial(&self, initial: u128) -> Digest<Slice16<u128>> {
+    pub const fn digest_with_initial(&self, initial: u16) -> Digest<Bytewise<u16>> {
         let value = init(self.algorithm, initial);
         Digest::new(self, value)
     }
 }
 
-impl<'a> Digest<'a, Slice16<u128>> {
-    const fn new(crc: &'a Crc<Slice16<u128>>, value: u128) -> Self {
+impl<'a> Digest<'a, Bytewise<u16>> {
+    const fn new(crc: &'a Crc<Bytewise<u16>>, value: u16) -> Self {
         Digest { crc, value }
     }
 
@@ -43,7 +42,7 @@ impl<'a> Digest<'a, Slice16<u128>> {
         self.value = self.crc.update(self.value, bytes);
     }
 
-    pub const fn finalize(self) -> u128 {
+    pub const fn finalize(self) -> u16 {
         finalize(self.crc.algorithm, self.value)
     }
 }

--- a/src/crc16/default.rs
+++ b/src/crc16/default.rs
@@ -1,25 +1,24 @@
-use crate::table::crc128_table_slice_16;
-use crate::{Algorithm, Crc, Digest, Slice16};
+use crate::crc16::{finalize, init, update_bytewise};
+use crate::table::crc16_table;
+use crate::{Algorithm, Crc, Digest};
 
-use super::{finalize, init, update_slice16};
-
-impl Crc<Slice16<u128>> {
-    pub const fn new(algorithm: &'static Algorithm<u128>) -> Self {
-        let table = crc128_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
+impl Crc<u16> {
+    pub const fn new(algorithm: &'static Algorithm<u16>) -> Self {
+        let table = crc16_table(algorithm.width, algorithm.poly, algorithm.refin);
         Self { algorithm, table }
     }
 
-    pub const fn checksum(&self, bytes: &[u8]) -> u128 {
+    pub const fn checksum(&self, bytes: &[u8]) -> u16 {
         let mut crc = init(self.algorithm, self.algorithm.init);
         crc = self.update(crc, bytes);
         finalize(self.algorithm, crc)
     }
 
-    const fn update(&self, crc: u128, bytes: &[u8]) -> u128 {
-        update_slice16(crc, self.algorithm.refin, &self.table, bytes)
+    const fn update(&self, crc: u16, bytes: &[u8]) -> u16 {
+        update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
     }
 
-    pub const fn digest(&self) -> Digest<Slice16<u128>> {
+    pub const fn digest(&self) -> Digest<u16> {
         self.digest_with_initial(self.algorithm.init)
     }
 
@@ -28,14 +27,14 @@ impl Crc<Slice16<u128>> {
     /// This overrides the initial value specified by the algorithm.
     /// The effects of the algorithm's properties `refin` and `width`
     /// are applied to the custom initial value.
-    pub const fn digest_with_initial(&self, initial: u128) -> Digest<Slice16<u128>> {
+    pub const fn digest_with_initial(&self, initial: u16) -> Digest<u16> {
         let value = init(self.algorithm, initial);
         Digest::new(self, value)
     }
 }
 
-impl<'a> Digest<'a, Slice16<u128>> {
-    const fn new(crc: &'a Crc<Slice16<u128>>, value: u128) -> Self {
+impl<'a> Digest<'a, u16> {
+    const fn new(crc: &'a Crc<u16>, value: u16) -> Self {
         Digest { crc, value }
     }
 
@@ -43,7 +42,7 @@ impl<'a> Digest<'a, Slice16<u128>> {
         self.value = self.crc.update(self.value, bytes);
     }
 
-    pub const fn finalize(self) -> u128 {
+    pub const fn finalize(self) -> u16 {
         finalize(self.crc.algorithm, self.value)
     }
 }

--- a/src/crc16/nolookup.rs
+++ b/src/crc16/nolookup.rs
@@ -1,0 +1,49 @@
+use crate::crc16::{finalize, init, update_nolookup};
+use crate::{Algorithm, Crc, Digest, NoTable};
+
+impl Crc<NoTable<u16>> {
+    pub const fn new(algorithm: &'static Algorithm<u16>) -> Self {
+        Self {
+            algorithm,
+            table: (),
+        }
+    }
+
+    pub const fn checksum(&self, bytes: &[u8]) -> u16 {
+        let mut crc = init(self.algorithm, self.algorithm.init);
+        crc = self.update(crc, bytes);
+        finalize(self.algorithm, crc)
+    }
+
+    const fn update(&self, crc: u16, bytes: &[u8]) -> u16 {
+        update_nolookup(crc, self.algorithm, bytes)
+    }
+
+    pub const fn digest(&self) -> Digest<NoTable<u16>> {
+        self.digest_with_initial(self.algorithm.init)
+    }
+
+    /// Construct a `Digest` with a given initial value.
+    ///
+    /// This overrides the initial value specified by the algorithm.
+    /// The effects of the algorithm's properties `refin` and `width`
+    /// are applied to the custom initial value.
+    pub const fn digest_with_initial(&self, initial: u16) -> Digest<NoTable<u16>> {
+        let value = init(self.algorithm, initial);
+        Digest::new(self, value)
+    }
+}
+
+impl<'a> Digest<'a, NoTable<u16>> {
+    const fn new(crc: &'a Crc<NoTable<u16>>, value: u16) -> Self {
+        Digest { crc, value }
+    }
+
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.value = self.crc.update(self.value, bytes);
+    }
+
+    pub const fn finalize(self) -> u16 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}

--- a/src/crc16/slice16.rs
+++ b/src/crc16/slice16.rs
@@ -1,25 +1,24 @@
-use crate::table::crc128_table_slice_16;
+use crate::crc16::{finalize, init, update_slice16};
+use crate::table::crc16_table_slice_16;
 use crate::{Algorithm, Crc, Digest, Slice16};
 
-use super::{finalize, init, update_slice16};
-
-impl Crc<Slice16<u128>> {
-    pub const fn new(algorithm: &'static Algorithm<u128>) -> Self {
-        let table = crc128_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
+impl Crc<Slice16<u16>> {
+    pub const fn new(algorithm: &'static Algorithm<u16>) -> Self {
+        let table = crc16_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
         Self { algorithm, table }
     }
 
-    pub const fn checksum(&self, bytes: &[u8]) -> u128 {
+    pub const fn checksum(&self, bytes: &[u8]) -> u16 {
         let mut crc = init(self.algorithm, self.algorithm.init);
         crc = self.update(crc, bytes);
         finalize(self.algorithm, crc)
     }
 
-    const fn update(&self, crc: u128, bytes: &[u8]) -> u128 {
+    const fn update(&self, crc: u16, bytes: &[u8]) -> u16 {
         update_slice16(crc, self.algorithm.refin, &self.table, bytes)
     }
 
-    pub const fn digest(&self) -> Digest<Slice16<u128>> {
+    pub const fn digest(&self) -> Digest<Slice16<u16>> {
         self.digest_with_initial(self.algorithm.init)
     }
 
@@ -28,14 +27,14 @@ impl Crc<Slice16<u128>> {
     /// This overrides the initial value specified by the algorithm.
     /// The effects of the algorithm's properties `refin` and `width`
     /// are applied to the custom initial value.
-    pub const fn digest_with_initial(&self, initial: u128) -> Digest<Slice16<u128>> {
+    pub const fn digest_with_initial(&self, initial: u16) -> Digest<Slice16<u16>> {
         let value = init(self.algorithm, initial);
         Digest::new(self, value)
     }
 }
 
-impl<'a> Digest<'a, Slice16<u128>> {
-    const fn new(crc: &'a Crc<Slice16<u128>>, value: u128) -> Self {
+impl<'a> Digest<'a, Slice16<u16>> {
+    const fn new(crc: &'a Crc<Slice16<u16>>, value: u16) -> Self {
         Digest { crc, value }
     }
 
@@ -43,7 +42,7 @@ impl<'a> Digest<'a, Slice16<u128>> {
         self.value = self.crc.update(self.value, bytes);
     }
 
-    pub const fn finalize(self) -> u128 {
+    pub const fn finalize(self) -> u16 {
         finalize(self.crc.algorithm, self.value)
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -34,6 +34,38 @@ pub(crate) const fn crc16_table(width: u8, poly: u16, reflect: bool) -> [u16; 25
     table
 }
 
+pub(crate) const fn crc16_table_slice_16(width: u8, poly: u16, reflect: bool) -> [[u16; 256]; 16] {
+    let poly = if reflect {
+        let poly = poly.reverse_bits();
+        poly >> (16u8 - width)
+    } else {
+        poly << (16u8 - width)
+    };
+
+    let mut table = [[0u16; 256]; 16];
+    let mut i = 0;
+    while i < 256 {
+        table[0][i] = crc16(poly, reflect, i as u16);
+        i += 1;
+    }
+
+    let mut i = 0;
+    while i < 256 {
+        let mut e = 1;
+        while e < 16 {
+            let one_lower = table[e - 1][i];
+            if reflect {
+                table[e][i] = (one_lower >> 8) ^ table[0][(one_lower & 0xFF) as usize];
+            } else {
+                table[e][i] = (one_lower << 8) ^ table[0][((one_lower >> 8) & 0xFF) as usize];
+            }
+            e += 1;
+        }
+        i += 1;
+    }
+    table
+}
+
 pub(crate) const fn crc32_table(width: u8, poly: u32, reflect: bool) -> [u32; 256] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
@@ -150,7 +182,7 @@ pub(crate) const fn crc128_table(width: u8, poly: u128, reflect: bool) -> [u128;
     table
 }
 
-pub(crate) const fn crc128_table_slice16(
+pub(crate) const fn crc128_table_slice_16(
     width: u8,
     poly: u128,
     reflect: bool,


### PR DESCRIPTION
Same old stuff for u16. Second to last 🙏 

Benches (this time on a Mac):

```
crc16/default           time:   [41.595 µs 41.660 µs 41.730 µs]
                        thrpt:  [374.43 MiB/s 375.06 MiB/s 375.65 MiB/s]

crc16/nolookup          time:   [189.08 µs 189.20 µs 189.31 µs]
                        thrpt:  [82.534 MiB/s 82.586 MiB/s 82.636 MiB/s]

crc16/bytewise          time:   [41.532 µs 41.567 µs 41.609 µs]
                        thrpt:  [375.52 MiB/s 375.90 MiB/s 376.22 MiB/s]

crc16/slice16           time:   [4.7172 µs 4.7269 µs 4.7378 µs]
                        thrpt:  [3.2206 GiB/s 3.2281 GiB/s 3.2347 GiB/s]
```