### PR TITLE
Assert in slice16 hot loop to avoid bounds checks.

### DIFF
--- a/src/crc128.rs
+++ b/src/crc128.rs
@@ -78,6 +78,8 @@ const fn update_slice16(
     let len = bytes.len();
     if reflect {
         while i + 16 < len {
+            assert!((i + 15) < len);
+
             let current0 = bytes[i] ^ crc as u8;
             let current1 = bytes[i + 1] ^ (crc >> 8) as u8;
             let current2 = bytes[i + 2] ^ (crc >> 16) as u8;
@@ -122,6 +124,8 @@ const fn update_slice16(
         }
     } else {
         while i + 16 < len {
+            assert!((i + 15) < len);
+
             let current0 = bytes[i] ^ (crc >> 120) as u8;
             let current1 = bytes[i + 1] ^ (crc >> 112) as u8;
             let current2 = bytes[i + 2] ^ (crc >> 104) as u8;

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -77,6 +77,8 @@ const fn update_slice16(
     let mut i = 0;
     if reflect {
         while i + 16 < len {
+            assert!((i + 15) < len);
+
             let current0 = bytes[i] ^ (crc as u8);
             let current1 = bytes[i + 1] ^ ((crc >> 8) as u8);
 
@@ -107,6 +109,8 @@ const fn update_slice16(
         }
     } else {
         while i + 16 < len {
+            assert!((i + 15) < len);
+
             let current0 = bytes[i] ^ ((crc >> 8) as u8);
             let current1 = bytes[i + 1] ^ (crc as u8);
 

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -76,8 +76,11 @@ const fn update_slice16(
     bytes: &[u8],
 ) -> u32 {
     let mut i = 0;
+    let len = bytes.len();
     if reflect {
-        while i + 16 <= bytes.len() {
+        while i + 16 <= len {
+            assert!((i + 15) < len);
+
             let mut current_slice = [bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3]];
 
             current_slice[0] ^= crc as u8;
@@ -106,13 +109,15 @@ const fn update_slice16(
         }
 
         // Last few bytes
-        while i < bytes.len() {
+        while i < len{
             let table_index = ((crc ^ bytes[i] as u32) & 0xFF) as usize;
             crc = table[0][table_index] ^ (crc >> 8);
             i += 1;
         }
     } else {
-        while i + 16 <= bytes.len() {
+        while i + 16 <= len {
+            assert!((i + 15) < len);
+
             let mut current_slice = [bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3]];
 
             current_slice[0] ^= (crc >> 24) as u8;
@@ -141,7 +146,7 @@ const fn update_slice16(
         }
 
         // Last few bytes
-        while i < bytes.len() {
+        while i < len {
             let table_index = (((crc >> 24) ^ bytes[i] as u32) & 0xFF) as usize;
             crc = table[0][table_index] ^ (crc << 8);
             i += 1;

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -79,6 +79,8 @@ const fn update_slice16(
     let len = bytes.len();
     if reflect {
         while i + 16 < len {
+            assert!((i + 15) < len);
+
             let current0 = bytes[i] ^ crc as u8;
             let current1 = bytes[i + 1] ^ (crc >> 8) as u8;
             let current2 = bytes[i + 2] ^ (crc >> 16) as u8;
@@ -115,6 +117,8 @@ const fn update_slice16(
         }
     } else {
         while i + 16 < len {
+            assert!((i + 15) < len);
+
             let current0 = bytes[i] ^ (crc >> 56) as u8;
             let current1 = bytes[i + 1] ^ (crc >> 48) as u8;
             let current2 = bytes[i + 2] ^ (crc >> 40) as u8;

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -58,6 +58,8 @@ const fn update_slice16(mut crc: u8, table: &[[u8; 256]; 16], bytes: &[u8]) -> u
     let mut i = 0;
 
     while i + 16 < len {
+        assert!((i + 15) < len);
+
         crc = table[0][bytes[i + 15] as usize]
             ^ table[1][bytes[i + 14] as usize]
             ^ table[2][bytes[i + 13] as usize]


### PR DESCRIPTION
Little help for compiler to eliminate bounds checks in hot loop. Biggest gain are in crc32/crc64/crc128

```
crc8/slice16            time:   [4.1465 µs 4.1499 µs 4.1542 µs]
                        thrpt:  [3.6731 GiB/s 3.6769 GiB/s 3.6799 GiB/s]
                 change:
                        time:   [-1.3003% -1.0348% -0.8107%] (p = 0.00 < 0.05)
                        thrpt:  [+0.8174% +1.0457% +1.3174%]
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

crc16/slice16           time:   [4.1916 µs 4.1950 µs 4.1989 µs]
                        thrpt:  [3.6340 GiB/s 3.6374 GiB/s 3.6404 GiB/s]
                 change:
                        time:   [-6.0076% -5.1733% -4.3995%] (p = 0.00 < 0.05)
                        thrpt:  [+4.6020% +5.4555% +6.3915%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

crc32/slice16           time:   [4.6525 µs 4.6926 µs 4.7364 µs]
                        thrpt:  [3.2216 GiB/s 3.2516 GiB/s 3.2797 GiB/s]
                 change:
                        time:   [-5.9927% -5.6196% -5.2235%] (p = 0.00 < 0.05)
                        thrpt:  [+5.5114% +5.9542% +6.3747%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe

crc64/slice16           time:   [5.3718 µs 5.3793 µs 5.3888 µs]
                        thrpt:  [2.8316 GiB/s 2.8366 GiB/s 2.8405 GiB/s]
                 change:
                        time:   [-13.005% -12.813% -12.565%] (p = 0.00 < 0.05)
                        thrpt:  [+14.371% +14.696% +14.950%]
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  4 (4.00%) low severe
  4 (4.00%) high mild
  12 (12.00%) high severe

crc82/slice16           time:   [15.866 µs 15.886 µs 15.911 µs]
                        thrpt:  [982.02 MiB/s 983.56 MiB/s 984.80 MiB/s]
                 change:
                        time:   [-9.7310% -9.2953% -8.9176%] (p = 0.00 < 0.05)
                        thrpt:  [+9.7907% +10.248% +10.780%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) high mild
  11 (11.00%) high severe
```