### PR TITLE
switch impls based on crate features for u8 as an example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["algorithms", "no-std"]
 edition = "2018"
 
 [features]
-default = ["slice16-defaults"]
 notable-defaults = []
 bytewise-defaults = []
 slice16-defaults = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ edition = "2018"
 
 [features]
 # use the "NoTable" implementation for the default Crc<uXXX> struct, using no additional memory for a lookup table.
-# Takes predence over "bytewise-memory-restrictions" and "slice16-memory-restrictions"
-no-table-memory-restrictions = []
+# Takes predence over "bytewise-mem-limit" and "slice16-mem-limit"
+no-table-mem-limit = []
 # use the "Bytewise" implementation for the default Crc<uXXX> struct, using 256 entries of the respective width for a lookup table.
-# Takes predence over "slice16-memory-restrictions" and is used if no feature is selected
-bytewise-memory-restrictions = []
+# Takes predence over "slice16-mem-limit" and is used if no feature is selected
+bytewise-mem-limit = []
 # use the "Slice16" implementation for the default Crc<uXXX> struct, using 256 * 16 entries of the respective width for a lookup table.
-# Can be overriden by setting "bytewise-memory-restrictions" and "slice16-memory-restrictions"
-slice16-memory-restrictions = []
+# Can be overriden by setting "bytewise-mem-limit" and "slice16-mem-limit"
+slice16-mem-limit = []
 
 [dependencies]
 crc-catalog = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,12 @@ keywords = ["crc", "crc16", "crc32", "crc64", "hash"]
 categories = ["algorithms", "no-std"]
 edition = "2018"
 
+[features]
+default = ["slice16-defaults"]
+notable-defaults = []
+bytewise-defaults = []
+slice16-defaults = []
+
 [dependencies]
 crc-catalog = "2.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,15 @@ categories = ["algorithms", "no-std"]
 edition = "2018"
 
 [features]
-notable-defaults = []
-bytewise-defaults = []
-slice16-defaults = []
+# use the "NoTable" implementation for the default Crc<uXXX> struct, using no additional memory for a lookup table.
+# Takes predence over "bytewise-memory-restrictions" and "slice16-memory-restrictions"
+no-table-memory-restrictions = []
+# use the "Bytewise" implementation for the default Crc<uXXX> struct, using 256 entries of the respective width for a lookup table.
+# Takes predence over "slice16-memory-restrictions" and is used if no feature is selected
+bytewise-memory-restrictions = []
+# use the "Slice16" implementation for the default Crc<uXXX> struct, using 256 * 16 entries of the respective width for a lookup table.
+# Can be overriden by setting "bytewise-memory-restrictions" and "slice16-memory-restrictions"
+slice16-memory-restrictions = []
 
 [dependencies]
 crc-catalog = "2.1.0"

--- a/src/crc128.rs
+++ b/src/crc128.rs
@@ -1,15 +1,8 @@
+use crate::util::crc128;
 use crc_catalog::Algorithm;
 
-use crate::util::crc128;
-
-#[cfg(any(
-    feature = "notable-defaults",
-    feature = "bytewise-defaults",
-    feature = "slice16-defaults"
-))]
-mod default;
-
 mod bytewise;
+mod default;
 mod nolookup;
 mod slice16;
 

--- a/src/crc128.rs
+++ b/src/crc128.rs
@@ -174,58 +174,92 @@ mod test {
 
     #[test]
     fn default_table_size() {
-        let table_size = core::mem::size_of::<<u128 as Implementation>::Table>();
+        const TABLE_SIZE: usize = core::mem::size_of::<<u128 as Implementation>::Table>();
+        const BYTES_PER_ENTRY: usize = 16;
         #[cfg(all(
-            feature = "notable-defaults",
-            feature = "bytewise-defaults",
-            feature = "slice16-defaults"
-        ))]
-        assert_eq!(0, table_size);
+        feature = "notable-defaults",
+        feature = "bytewise-defaults",
+        feature = "slice16-defaults"
+        ))]{
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            feature = "bytewise-defaults",
-            not(feature = "slice16-defaults")
+        feature = "notable-defaults",
+        feature = "bytewise-defaults",
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+        feature = "notable-defaults",
+        not(feature = "bytewise-defaults"),
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+        feature = "notable-defaults",
+        not(feature = "bytewise-defaults"),
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            feature = "bytewise-defaults",
-            feature = "slice16-defaults"
+        not(feature = "notable-defaults"),
+        feature = "bytewise-defaults",
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(256 * 16, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            feature = "bytewise-defaults",
-            not(feature = "slice16-defaults")
+        not(feature = "notable-defaults"),
+        feature = "bytewise-defaults",
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(256 * 16, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+        not(feature = "notable-defaults"),
+        not(feature = "bytewise-defaults"),
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(256 * 16 * 16, table_size);
+        {
+            const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+        not(feature = "notable-defaults"),
+        not(feature = "bytewise-defaults"),
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(256 * 16, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
+        let _ = TABLE_SIZE;
+        let _ = BYTES_PER_ENTRY;
     }
 
     /// Test this opitimized version against the well known implementation to ensure correctness

--- a/src/crc128.rs
+++ b/src/crc128.rs
@@ -177,9 +177,9 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u128 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 16;
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            feature = "bytewise-memory-restrictions",
-            feature = "slice16-memory-restrictions"
+            feature = "no-table-mem-limit",
+            feature = "bytewise-mem-limit",
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -187,9 +187,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            feature = "bytewise-memory-restrictions",
-            not(feature = "slice16-memory-restrictions")
+            feature = "no-table-mem-limit",
+            feature = "bytewise-mem-limit",
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -197,9 +197,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            feature = "no-table-mem-limit",
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -207,9 +207,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            feature = "no-table-mem-limit",
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -218,9 +218,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions",
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit",
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -228,9 +228,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions",
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit",
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -239,9 +239,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -250,9 +250,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;

--- a/src/crc128.rs
+++ b/src/crc128.rs
@@ -177,18 +177,18 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u128 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 16;
         #[cfg(all(
-        feature = "notable-defaults",
-        feature = "bytewise-defaults",
-        feature = "slice16-defaults"
+        feature = "no-table-memory-restrictions",
+        feature = "bytewise-memory-restrictions",
+        feature = "slice16-memory-restrictions"
         ))]{
             const EXPECTED: usize = 0;
             let _ = EXPECTED;
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        feature = "bytewise-defaults",
-        not(feature = "slice16-defaults")
+        feature = "no-table-memory-restrictions",
+        feature = "bytewise-memory-restrictions",
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -196,9 +196,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        not(feature = "bytewise-defaults"),
-        feature = "slice16-defaults"
+        feature = "no-table-memory-restrictions",
+        not(feature = "bytewise-memory-restrictions"),
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -206,9 +206,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        not(feature = "bytewise-defaults"),
-        not(feature = "slice16-defaults")
+        feature = "no-table-memory-restrictions",
+        not(feature = "bytewise-memory-restrictions"),
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -217,9 +217,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        feature = "bytewise-defaults",
-        feature = "slice16-defaults"
+        not(feature = "no-table-memory-restrictions"),
+        feature = "bytewise-memory-restrictions",
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -227,9 +227,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        feature = "bytewise-defaults",
-        not(feature = "slice16-defaults")
+        not(feature = "no-table-memory-restrictions"),
+        feature = "bytewise-memory-restrictions",
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -238,9 +238,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        not(feature = "bytewise-defaults"),
-        feature = "slice16-defaults"
+        not(feature = "no-table-memory-restrictions"),
+        not(feature = "bytewise-memory-restrictions"),
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -249,9 +249,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        not(feature = "bytewise-defaults"),
-        not(feature = "slice16-defaults")
+        not(feature = "no-table-memory-restrictions"),
+        not(feature = "bytewise-memory-restrictions"),
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -262,7 +262,7 @@ mod test {
         let _ = BYTES_PER_ENTRY;
     }
 
-    /// Test this opitimized version against the well known implementation to ensure correctness
+    /// Test this optimized version against the well known implementation to ensure correctness
     #[test]
     fn correctness() {
         let data: &[&str] = &[

--- a/src/crc128.rs
+++ b/src/crc128.rs
@@ -177,18 +177,9 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u128 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 16;
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        feature = "bytewise-memory-restrictions",
-        feature = "slice16-memory-restrictions"
-        ))]{
-            const EXPECTED: usize = 0;
-            let _ = EXPECTED;
-            const _: () = assert!(EXPECTED == TABLE_SIZE);
-        }
-        #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        feature = "bytewise-memory-restrictions",
-        not(feature = "slice16-memory-restrictions")
+            feature = "no-table-memory-restrictions",
+            feature = "bytewise-memory-restrictions",
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -196,9 +187,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        not(feature = "bytewise-memory-restrictions"),
-        feature = "slice16-memory-restrictions"
+            feature = "no-table-memory-restrictions",
+            feature = "bytewise-memory-restrictions",
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -206,9 +197,19 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        not(feature = "bytewise-memory-restrictions"),
-        not(feature = "slice16-memory-restrictions")
+            feature = "no-table-memory-restrictions",
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
+        ))]
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
+        #[cfg(all(
+            feature = "no-table-memory-restrictions",
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -217,9 +218,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        feature = "bytewise-memory-restrictions",
-        feature = "slice16-memory-restrictions"
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions",
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -227,9 +228,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        feature = "bytewise-memory-restrictions",
-        not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions",
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -238,9 +239,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        not(feature = "bytewise-memory-restrictions"),
-        feature = "slice16-memory-restrictions"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -249,9 +250,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        not(feature = "bytewise-memory-restrictions"),
-        not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;

--- a/src/crc128.rs
+++ b/src/crc128.rs
@@ -2,8 +2,14 @@ use crc_catalog::Algorithm;
 
 use crate::util::crc128;
 
-mod bytewise;
+#[cfg(any(
+    feature = "notable-defaults",
+    feature = "bytewise-defaults",
+    feature = "slice16-defaults"
+))]
 mod default;
+
+mod bytewise;
 mod nolookup;
 mod slice16;
 

--- a/src/crc128.rs
+++ b/src/crc128.rs
@@ -169,8 +169,64 @@ const fn update_slice16(
 
 #[cfg(test)]
 mod test {
-    use crate::{Bytewise, Crc, NoTable, Slice16};
+    use crate::{Bytewise, Crc, Implementation, NoTable, Slice16};
     use crc_catalog::{Algorithm, CRC_82_DARC};
+
+    #[test]
+    fn default_table_size() {
+        let table_size = core::mem::size_of::<<u128 as Implementation>::Table>();
+        #[cfg(all(
+            feature = "notable-defaults",
+            feature = "bytewise-defaults",
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            feature = "bytewise-defaults",
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(0, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            feature = "bytewise-defaults",
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(256 * 16, table_size);
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            feature = "bytewise-defaults",
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(256 * 16, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(256 * 16 * 16, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(256 * 16, table_size);
+    }
 
     /// Test this opitimized version against the well known implementation to ensure correctness
     #[test]

--- a/src/crc128/default.rs
+++ b/src/crc128/default.rs
@@ -1,15 +1,15 @@
 use crate::crc128::{finalize, init};
 use crate::{Algorithm, Crc, Digest, Implementation};
 
-#[cfg(feature = "no-table-memory-restrictions")]
+#[cfg(feature = "no-table-mem-limit")]
 impl Implementation for u128 {
     type Width = u128;
     type Table = ();
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    feature = "bytewise-memory-restrictions"
+    not(feature = "no-table-mem-limit"),
+    feature = "bytewise-mem-limit"
 ))]
 impl Implementation for u128 {
     type Width = u128;
@@ -17,9 +17,9 @@ impl Implementation for u128 {
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    not(feature = "bytewise-memory-restrictions"),
-    feature = "slice16-memory-restrictions"
+    not(feature = "no-table-mem-limit"),
+    not(feature = "bytewise-mem-limit"),
+    feature = "slice16-mem-limit"
 ))]
 impl Implementation for u128 {
     type Width = u128;
@@ -27,9 +27,9 @@ impl Implementation for u128 {
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    not(feature = "bytewise-memory-restrictions"),
-    not(feature = "slice16-memory-restrictions")
+    not(feature = "no-table-mem-limit"),
+    not(feature = "bytewise-mem-limit"),
+    not(feature = "slice16-mem-limit")
 ))]
 impl Implementation for u128 {
     type Width = u128;
@@ -39,27 +39,27 @@ impl Implementation for u128 {
 impl Crc<u128> {
     pub const fn new(algorithm: &'static Algorithm<u128>) -> Self {
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         let table =
             crate::table::crc128_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit"
         ))]
         let table = crate::table::crc128_table(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(feature = "no-table-memory-restrictions")]
+        #[cfg(feature = "no-table-mem-limit")]
         #[allow(clippy::let_unit_value)]
         let table = ();
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         let table = crate::table::crc128_table(algorithm.width, algorithm.poly, algorithm.refin);
 
@@ -74,31 +74,31 @@ impl Crc<u128> {
 
     const fn update(&self, crc: u128, bytes: &[u8]) -> u128 {
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit"
         ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(feature = "no-table-memory-restrictions")]
+        #[cfg(feature = "no-table-mem-limit")]
         {
             super::update_nolookup(crc, self.algorithm, bytes)
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)

--- a/src/crc128/default.rs
+++ b/src/crc128/default.rs
@@ -7,7 +7,10 @@ impl Implementation for u128 {
     type Table = ();
 }
 
-#[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+#[cfg(all(
+    not(feature = "no-table-memory-restrictions"),
+    feature = "bytewise-memory-restrictions"
+))]
 impl Implementation for u128 {
     type Width = u128;
     type Table = [u128; 256];
@@ -43,7 +46,10 @@ impl Crc<u128> {
         let table =
             crate::table::crc128_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+        #[cfg(all(
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions"
+        ))]
         let table = crate::table::crc128_table(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(feature = "no-table-memory-restrictions")]
@@ -76,7 +82,10 @@ impl Crc<u128> {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+        #[cfg(all(
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions"
+        ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }

--- a/src/crc128/default.rs
+++ b/src/crc128/default.rs
@@ -1,22 +1,22 @@
 use crate::crc128::{finalize, init};
 use crate::{Algorithm, Crc, Digest, Implementation};
 
-#[cfg(feature = "notable-defaults")]
+#[cfg(feature = "no-table-memory-restrictions")]
 impl Implementation for u128 {
     type Width = u128;
     type Table = ();
 }
 
-#[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+#[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
 impl Implementation for u128 {
     type Width = u128;
     type Table = [u128; 256];
 }
 
 #[cfg(all(
-    not(feature = "notable-defaults"),
-    not(feature = "bytewise-defaults"),
-    feature = "slice16-defaults"
+    not(feature = "no-table-memory-restrictions"),
+    not(feature = "bytewise-memory-restrictions"),
+    feature = "slice16-memory-restrictions"
 ))]
 impl Implementation for u128 {
     type Width = u128;
@@ -24,9 +24,9 @@ impl Implementation for u128 {
 }
 
 #[cfg(all(
-    not(feature = "notable-defaults"),
-    not(feature = "bytewise-defaults"),
-    not(feature = "slice16-defaults")
+    not(feature = "no-table-memory-restrictions"),
+    not(feature = "bytewise-memory-restrictions"),
+    not(feature = "slice16-memory-restrictions")
 ))]
 impl Implementation for u128 {
     type Width = u128;
@@ -36,24 +36,24 @@ impl Implementation for u128 {
 impl Crc<u128> {
     pub const fn new(algorithm: &'static Algorithm<u128>) -> Self {
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         let table =
             crate::table::crc128_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
         let table = crate::table::crc128_table(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(feature = "notable-defaults")]
+        #[cfg(feature = "no-table-memory-restrictions")]
         #[allow(clippy::let_unit_value)]
         let table = ();
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         let table = crate::table::crc128_table(algorithm.width, algorithm.poly, algorithm.refin);
 
@@ -68,28 +68,28 @@ impl Crc<u128> {
 
     const fn update(&self, crc: u128, bytes: &[u8]) -> u128 {
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(feature = "notable-defaults")]
+        #[cfg(feature = "no-table-memory-restrictions")]
         {
             super::update_nolookup(crc, self.algorithm, bytes)
         }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)

--- a/src/crc128/default.rs
+++ b/src/crc128/default.rs
@@ -7,10 +7,7 @@ impl Implementation for u128 {
     type Table = ();
 }
 
-#[cfg(all(
-    not(feature = "no-table-mem-limit"),
-    feature = "bytewise-mem-limit"
-))]
+#[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
 impl Implementation for u128 {
     type Width = u128;
     type Table = [u128; 256];
@@ -46,10 +43,7 @@ impl Crc<u128> {
         let table =
             crate::table::crc128_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(
-            not(feature = "no-table-mem-limit"),
-            feature = "bytewise-mem-limit"
-        ))]
+        #[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
         let table = crate::table::crc128_table(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(feature = "no-table-mem-limit")]
@@ -82,10 +76,7 @@ impl Crc<u128> {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(all(
-            not(feature = "no-table-mem-limit"),
-            feature = "bytewise-mem-limit"
-        ))]
+        #[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }

--- a/src/crc128/default.rs
+++ b/src/crc128/default.rs
@@ -1,11 +1,44 @@
-use crate::table::crc128_table;
-use crate::{Algorithm, Crc, Digest};
+use crate::{Algorithm, Crc, Digest, Implementation};
 
-use super::{finalize, init, update_bytewise};
+use super::{finalize, init};
+
+#[cfg(feature = "notable-defaults")]
+impl Implementation for u128 {
+    type Width = u128;
+    type Table = ();
+}
+
+#[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+impl Implementation for u128 {
+    type Width = u128;
+    type Table = [u128; 256];
+}
+
+#[cfg(all(
+    not(feature = "notable-defaults"),
+    not(feature = "bytewise-defaults"),
+    feature = "slice16-defaults"
+))]
+impl Implementation for u128 {
+    type Width = u128;
+    type Table = [[u128; 256]; 16];
+}
 
 impl Crc<u128> {
     pub const fn new(algorithm: &'static Algorithm<u128>) -> Self {
-        let table = crc128_table(algorithm.width, algorithm.poly, algorithm.refin);
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        let table =
+            crate::table::crc128_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
+
+        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        let table = crate::table::crc128_table(algorithm.width, algorithm.poly, algorithm.refin);
+
+        #[cfg(feature = "notable-defaults")]
+        let table = ();
         Self { algorithm, table }
     }
 
@@ -16,7 +49,24 @@ impl Crc<u128> {
     }
 
     const fn update(&self, crc: u128, bytes: &[u8]) -> u128 {
-        update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        {
+            super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
+        }
+
+        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        {
+            super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
+        }
+
+        #[cfg(feature = "notable-defaults")]
+        {
+            super::update_nolookup(crc, self.algorithm, bytes)
+        }
     }
 
     pub const fn digest(&self) -> Digest<u128> {

--- a/src/crc128/default.rs
+++ b/src/crc128/default.rs
@@ -1,6 +1,5 @@
+use crate::crc128::{finalize, init};
 use crate::{Algorithm, Crc, Digest, Implementation};
-
-use super::{finalize, init};
 
 #[cfg(feature = "notable-defaults")]
 impl Implementation for u128 {
@@ -24,6 +23,16 @@ impl Implementation for u128 {
     type Table = [[u128; 256]; 16];
 }
 
+#[cfg(all(
+    not(feature = "notable-defaults"),
+    not(feature = "bytewise-defaults"),
+    not(feature = "slice16-defaults")
+))]
+impl Implementation for u128 {
+    type Width = u128;
+    type Table = [u128; 256];
+}
+
 impl Crc<u128> {
     pub const fn new(algorithm: &'static Algorithm<u128>) -> Self {
         #[cfg(all(
@@ -38,7 +47,16 @@ impl Crc<u128> {
         let table = crate::table::crc128_table(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(feature = "notable-defaults")]
+        #[allow(clippy::let_unit_value)]
         let table = ();
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        let table = crate::table::crc128_table(algorithm.width, algorithm.poly, algorithm.refin);
+
         Self { algorithm, table }
     }
 
@@ -66,6 +84,15 @@ impl Crc<u128> {
         #[cfg(feature = "notable-defaults")]
         {
             super::update_nolookup(crc, self.algorithm, bytes)
+        }
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        {
+            super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }
     }
 

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -141,8 +141,64 @@ const fn update_slice16(
 
 #[cfg(test)]
 mod test {
-    use crate::{Bytewise, Crc, NoTable, Slice16};
+    use crate::{Bytewise, Crc, Implementation, NoTable, Slice16};
     use crc_catalog::{Algorithm, CRC_16_IBM_SDLC};
+
+    #[test]
+    fn default_table_size() {
+        let table_size = core::mem::size_of::<<u16 as Implementation>::Table>();
+        #[cfg(all(
+            feature = "notable-defaults",
+            feature = "bytewise-defaults",
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            feature = "bytewise-defaults",
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(0, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            feature = "bytewise-defaults",
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(256 * 2, table_size);
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            feature = "bytewise-defaults",
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(256 * 2, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(256 * 16 * 2, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(256 * 2, table_size);
+    }
 
     /// Test this opitimized version against the well known implementation to ensure correctness
     #[test]

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -149,18 +149,18 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u16 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 2;
         #[cfg(all(
-        feature = "notable-defaults",
-        feature = "bytewise-defaults",
-        feature = "slice16-defaults"
+        feature = "no-table-memory-restrictions",
+        feature = "bytewise-memory-restrictions",
+        feature = "slice16-memory-restrictions"
         ))]{
             const EXPECTED: usize = 0;
             let _ = EXPECTED;
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        feature = "bytewise-defaults",
-        not(feature = "slice16-defaults")
+        feature = "no-table-memory-restrictions",
+        feature = "bytewise-memory-restrictions",
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -168,9 +168,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        not(feature = "bytewise-defaults"),
-        feature = "slice16-defaults"
+        feature = "no-table-memory-restrictions",
+        not(feature = "bytewise-memory-restrictions"),
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -178,9 +178,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        not(feature = "bytewise-defaults"),
-        not(feature = "slice16-defaults")
+        feature = "no-table-memory-restrictions",
+        not(feature = "bytewise-memory-restrictions"),
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -189,9 +189,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        feature = "bytewise-defaults",
-        feature = "slice16-defaults"
+        not(feature = "no-table-memory-restrictions"),
+        feature = "bytewise-memory-restrictions",
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -199,9 +199,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        feature = "bytewise-defaults",
-        not(feature = "slice16-defaults")
+        not(feature = "no-table-memory-restrictions"),
+        feature = "bytewise-memory-restrictions",
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -210,9 +210,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        not(feature = "bytewise-defaults"),
-        feature = "slice16-defaults"
+        not(feature = "no-table-memory-restrictions"),
+        not(feature = "bytewise-memory-restrictions"),
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -221,9 +221,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        not(feature = "bytewise-defaults"),
-        not(feature = "slice16-defaults")
+        not(feature = "no-table-memory-restrictions"),
+        not(feature = "bytewise-memory-restrictions"),
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -234,7 +234,7 @@ mod test {
         let _ = BYTES_PER_ENTRY;
     }
 
-    /// Test this opitimized version against the well known implementation to ensure correctness
+    /// Test this optimized version against the well known implementation to ensure correctness
     #[test]
     fn correctness() {
         let data: &[&str] = &[

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -1,8 +1,14 @@
 use crate::util::crc16;
 use crc_catalog::Algorithm;
 
-mod bytewise;
+#[cfg(any(
+    feature = "notable-defaults",
+    feature = "bytewise-defaults",
+    feature = "slice16-defaults"
+))]
 mod default;
+
+mod bytewise;
 mod nolookup;
 mod slice16;
 

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -146,58 +146,92 @@ mod test {
 
     #[test]
     fn default_table_size() {
-        let table_size = core::mem::size_of::<<u16 as Implementation>::Table>();
+        const TABLE_SIZE: usize = core::mem::size_of::<<u16 as Implementation>::Table>();
+        const BYTES_PER_ENTRY: usize = 2;
         #[cfg(all(
-            feature = "notable-defaults",
-            feature = "bytewise-defaults",
-            feature = "slice16-defaults"
-        ))]
-        assert_eq!(0, table_size);
+        feature = "notable-defaults",
+        feature = "bytewise-defaults",
+        feature = "slice16-defaults"
+        ))]{
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            feature = "bytewise-defaults",
-            not(feature = "slice16-defaults")
+        feature = "notable-defaults",
+        feature = "bytewise-defaults",
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+        feature = "notable-defaults",
+        not(feature = "bytewise-defaults"),
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+        feature = "notable-defaults",
+        not(feature = "bytewise-defaults"),
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            feature = "bytewise-defaults",
-            feature = "slice16-defaults"
+        not(feature = "notable-defaults"),
+        feature = "bytewise-defaults",
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(256 * 2, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            feature = "bytewise-defaults",
-            not(feature = "slice16-defaults")
+        not(feature = "notable-defaults"),
+        feature = "bytewise-defaults",
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(256 * 2, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+        not(feature = "notable-defaults"),
+        not(feature = "bytewise-defaults"),
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(256 * 16 * 2, table_size);
+        {
+            const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+        not(feature = "notable-defaults"),
+        not(feature = "bytewise-defaults"),
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(256 * 2, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
+        let _ = TABLE_SIZE;
+        let _ = BYTES_PER_ENTRY;
     }
 
     /// Test this opitimized version against the well known implementation to ensure correctness

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -1,14 +1,8 @@
 use crate::util::crc16;
 use crc_catalog::Algorithm;
 
-#[cfg(any(
-    feature = "notable-defaults",
-    feature = "bytewise-defaults",
-    feature = "slice16-defaults"
-))]
-mod default;
-
 mod bytewise;
+mod default;
 mod nolookup;
 mod slice16;
 

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -149,9 +149,9 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u16 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 2;
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            feature = "bytewise-memory-restrictions",
-            feature = "slice16-memory-restrictions"
+            feature = "no-table-mem-limit",
+            feature = "bytewise-mem-limit",
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -159,9 +159,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            feature = "bytewise-memory-restrictions",
-            not(feature = "slice16-memory-restrictions")
+            feature = "no-table-mem-limit",
+            feature = "bytewise-mem-limit",
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -169,9 +169,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            feature = "no-table-mem-limit",
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -179,9 +179,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            feature = "no-table-mem-limit",
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -190,9 +190,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions",
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit",
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -200,9 +200,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions",
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit",
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -211,9 +211,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -222,9 +222,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -149,18 +149,9 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u16 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 2;
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        feature = "bytewise-memory-restrictions",
-        feature = "slice16-memory-restrictions"
-        ))]{
-            const EXPECTED: usize = 0;
-            let _ = EXPECTED;
-            const _: () = assert!(EXPECTED == TABLE_SIZE);
-        }
-        #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        feature = "bytewise-memory-restrictions",
-        not(feature = "slice16-memory-restrictions")
+            feature = "no-table-memory-restrictions",
+            feature = "bytewise-memory-restrictions",
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -168,9 +159,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        not(feature = "bytewise-memory-restrictions"),
-        feature = "slice16-memory-restrictions"
+            feature = "no-table-memory-restrictions",
+            feature = "bytewise-memory-restrictions",
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -178,9 +169,19 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        not(feature = "bytewise-memory-restrictions"),
-        not(feature = "slice16-memory-restrictions")
+            feature = "no-table-memory-restrictions",
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
+        ))]
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
+        #[cfg(all(
+            feature = "no-table-memory-restrictions",
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -189,9 +190,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        feature = "bytewise-memory-restrictions",
-        feature = "slice16-memory-restrictions"
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions",
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -199,9 +200,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        feature = "bytewise-memory-restrictions",
-        not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions",
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -210,9 +211,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        not(feature = "bytewise-memory-restrictions"),
-        feature = "slice16-memory-restrictions"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -221,9 +222,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        not(feature = "bytewise-memory-restrictions"),
-        not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;

--- a/src/crc16/default.rs
+++ b/src/crc16/default.rs
@@ -1,22 +1,22 @@
 use crate::crc16::{finalize, init};
 use crate::{Algorithm, Crc, Digest, Implementation};
 
-#[cfg(feature = "notable-defaults")]
+#[cfg(feature = "no-table-memory-restrictions")]
 impl Implementation for u16 {
     type Width = u16;
     type Table = ();
 }
 
-#[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+#[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
 impl Implementation for u16 {
     type Width = u16;
     type Table = [u16; 256];
 }
 
 #[cfg(all(
-    not(feature = "notable-defaults"),
-    not(feature = "bytewise-defaults"),
-    feature = "slice16-defaults"
+    not(feature = "no-table-memory-restrictions"),
+    not(feature = "bytewise-memory-restrictions"),
+    feature = "slice16-memory-restrictions"
 ))]
 impl Implementation for u16 {
     type Width = u16;
@@ -24,9 +24,9 @@ impl Implementation for u16 {
 }
 
 #[cfg(all(
-    not(feature = "notable-defaults"),
-    not(feature = "bytewise-defaults"),
-    not(feature = "slice16-defaults")
+    not(feature = "no-table-memory-restrictions"),
+    not(feature = "bytewise-memory-restrictions"),
+    not(feature = "slice16-memory-restrictions")
 ))]
 impl Implementation for u16 {
     type Width = u16;
@@ -36,24 +36,24 @@ impl Implementation for u16 {
 impl Crc<u16> {
     pub const fn new(algorithm: &'static Algorithm<u16>) -> Self {
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         let table =
             crate::table::crc16_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
         let table = crate::table::crc16_table(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(feature = "notable-defaults")]
+        #[cfg(feature = "no-table-memory-restrictions")]
         #[allow(clippy::let_unit_value)]
         let table = ();
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         let table = crate::table::crc16_table(algorithm.width, algorithm.poly, algorithm.refin);
 
@@ -68,28 +68,28 @@ impl Crc<u16> {
 
     const fn update(&self, crc: u16, bytes: &[u8]) -> u16 {
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(feature = "notable-defaults")]
+        #[cfg(feature = "no-table-memory-restrictions")]
         {
             super::update_nolookup(crc, self.algorithm, bytes)
         }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)

--- a/src/crc16/default.rs
+++ b/src/crc16/default.rs
@@ -1,15 +1,15 @@
 use crate::crc16::{finalize, init};
 use crate::{Algorithm, Crc, Digest, Implementation};
 
-#[cfg(feature = "no-table-memory-restrictions")]
+#[cfg(feature = "no-table-mem-limit")]
 impl Implementation for u16 {
     type Width = u16;
     type Table = ();
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    feature = "bytewise-memory-restrictions"
+    not(feature = "no-table-mem-limit"),
+    feature = "bytewise-mem-limit"
 ))]
 impl Implementation for u16 {
     type Width = u16;
@@ -17,9 +17,9 @@ impl Implementation for u16 {
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    not(feature = "bytewise-memory-restrictions"),
-    feature = "slice16-memory-restrictions"
+    not(feature = "no-table-mem-limit"),
+    not(feature = "bytewise-mem-limit"),
+    feature = "slice16-mem-limit"
 ))]
 impl Implementation for u16 {
     type Width = u16;
@@ -27,9 +27,9 @@ impl Implementation for u16 {
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    not(feature = "bytewise-memory-restrictions"),
-    not(feature = "slice16-memory-restrictions")
+    not(feature = "no-table-mem-limit"),
+    not(feature = "bytewise-mem-limit"),
+    not(feature = "slice16-mem-limit")
 ))]
 impl Implementation for u16 {
     type Width = u16;
@@ -39,27 +39,27 @@ impl Implementation for u16 {
 impl Crc<u16> {
     pub const fn new(algorithm: &'static Algorithm<u16>) -> Self {
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         let table =
             crate::table::crc16_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit"
         ))]
         let table = crate::table::crc16_table(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(feature = "no-table-memory-restrictions")]
+        #[cfg(feature = "no-table-mem-limit")]
         #[allow(clippy::let_unit_value)]
         let table = ();
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         let table = crate::table::crc16_table(algorithm.width, algorithm.poly, algorithm.refin);
 
@@ -74,31 +74,31 @@ impl Crc<u16> {
 
     const fn update(&self, crc: u16, bytes: &[u8]) -> u16 {
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit"
         ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(feature = "no-table-memory-restrictions")]
+        #[cfg(feature = "no-table-mem-limit")]
         {
             super::update_nolookup(crc, self.algorithm, bytes)
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)

--- a/src/crc16/default.rs
+++ b/src/crc16/default.rs
@@ -7,10 +7,7 @@ impl Implementation for u16 {
     type Table = ();
 }
 
-#[cfg(all(
-    not(feature = "no-table-mem-limit"),
-    feature = "bytewise-mem-limit"
-))]
+#[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
 impl Implementation for u16 {
     type Width = u16;
     type Table = [u16; 256];
@@ -46,10 +43,7 @@ impl Crc<u16> {
         let table =
             crate::table::crc16_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(
-            not(feature = "no-table-mem-limit"),
-            feature = "bytewise-mem-limit"
-        ))]
+        #[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
         let table = crate::table::crc16_table(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(feature = "no-table-mem-limit")]
@@ -82,10 +76,7 @@ impl Crc<u16> {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(all(
-            not(feature = "no-table-mem-limit"),
-            feature = "bytewise-mem-limit"
-        ))]
+        #[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }

--- a/src/crc16/default.rs
+++ b/src/crc16/default.rs
@@ -7,7 +7,10 @@ impl Implementation for u16 {
     type Table = ();
 }
 
-#[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+#[cfg(all(
+    not(feature = "no-table-memory-restrictions"),
+    feature = "bytewise-memory-restrictions"
+))]
 impl Implementation for u16 {
     type Width = u16;
     type Table = [u16; 256];
@@ -43,7 +46,10 @@ impl Crc<u16> {
         let table =
             crate::table::crc16_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+        #[cfg(all(
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions"
+        ))]
         let table = crate::table::crc16_table(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(feature = "no-table-memory-restrictions")]
@@ -76,7 +82,10 @@ impl Crc<u16> {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+        #[cfg(all(
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions"
+        ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -160,18 +160,18 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u32 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 4;
         #[cfg(all(
-        feature = "notable-defaults",
-        feature = "bytewise-defaults",
-        feature = "slice16-defaults"
+        feature = "no-table-memory-restrictions",
+        feature = "bytewise-memory-restrictions",
+        feature = "slice16-memory-restrictions"
         ))]{
             const EXPECTED: usize = 0;
             let _ = EXPECTED;
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        feature = "bytewise-defaults",
-        not(feature = "slice16-defaults")
+        feature = "no-table-memory-restrictions",
+        feature = "bytewise-memory-restrictions",
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -179,9 +179,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        not(feature = "bytewise-defaults"),
-        feature = "slice16-defaults"
+        feature = "no-table-memory-restrictions",
+        not(feature = "bytewise-memory-restrictions"),
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -189,9 +189,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        not(feature = "bytewise-defaults"),
-        not(feature = "slice16-defaults")
+        feature = "no-table-memory-restrictions",
+        not(feature = "bytewise-memory-restrictions"),
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -200,9 +200,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        feature = "bytewise-defaults",
-        feature = "slice16-defaults"
+        not(feature = "no-table-memory-restrictions"),
+        feature = "bytewise-memory-restrictions",
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -210,9 +210,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        feature = "bytewise-defaults",
-        not(feature = "slice16-defaults")
+        not(feature = "no-table-memory-restrictions"),
+        feature = "bytewise-memory-restrictions",
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -221,9 +221,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        not(feature = "bytewise-defaults"),
-        feature = "slice16-defaults"
+        not(feature = "no-table-memory-restrictions"),
+        not(feature = "bytewise-memory-restrictions"),
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -232,9 +232,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        not(feature = "bytewise-defaults"),
-        not(feature = "slice16-defaults")
+        not(feature = "no-table-memory-restrictions"),
+        not(feature = "bytewise-memory-restrictions"),
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -245,7 +245,7 @@ mod test {
         let _ = BYTES_PER_ENTRY;
     }
 
-    /// Test this opitimized version against the well known implementation to ensure correctness
+    /// Test this optimized version against the well known implementation to ensure correctness
     #[test]
     fn correctness() {
         let data: &[&str] = &[

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -1,5 +1,11 @@
-mod bytewise;
+#[cfg(any(
+    feature = "notable-defaults",
+    feature = "bytewise-defaults",
+    feature = "slice16-defaults"
+))]
 mod default;
+
+mod bytewise;
 mod nolookup;
 mod slice16;
 

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -152,8 +152,64 @@ const fn update_slice16(
 
 #[cfg(test)]
 mod test {
-    use crate::{Bytewise, Crc, NoTable, Slice16};
+    use crate::{Bytewise, Crc, Implementation, NoTable, Slice16};
     use crc_catalog::{Algorithm, CRC_32_ISCSI};
+
+    #[test]
+    fn default_table_size() {
+        let table_size = core::mem::size_of::<<u32 as Implementation>::Table>();
+        #[cfg(all(
+            feature = "notable-defaults",
+            feature = "bytewise-defaults",
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            feature = "bytewise-defaults",
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(0, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            feature = "bytewise-defaults",
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(256 * 4, table_size);
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            feature = "bytewise-defaults",
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(256 * 4, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(256 * 16 * 4, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(256 * 4, table_size);
+    }
 
     /// Test this opitimized version against the well known implementation to ensure correctness
     #[test]

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -160,9 +160,9 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u32 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 4;
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            feature = "bytewise-memory-restrictions",
-            feature = "slice16-memory-restrictions"
+            feature = "no-table-mem-limit",
+            feature = "bytewise-mem-limit",
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -170,9 +170,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            feature = "bytewise-memory-restrictions",
-            not(feature = "slice16-memory-restrictions")
+            feature = "no-table-mem-limit",
+            feature = "bytewise-mem-limit",
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -180,9 +180,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            feature = "no-table-mem-limit",
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -190,9 +190,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            feature = "no-table-mem-limit",
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -201,9 +201,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions",
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit",
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -211,9 +211,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions",
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit",
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -222,9 +222,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -233,9 +233,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -157,58 +157,92 @@ mod test {
 
     #[test]
     fn default_table_size() {
-        let table_size = core::mem::size_of::<<u32 as Implementation>::Table>();
+        const TABLE_SIZE: usize = core::mem::size_of::<<u32 as Implementation>::Table>();
+        const BYTES_PER_ENTRY: usize = 4;
         #[cfg(all(
-            feature = "notable-defaults",
-            feature = "bytewise-defaults",
-            feature = "slice16-defaults"
-        ))]
-        assert_eq!(0, table_size);
+        feature = "notable-defaults",
+        feature = "bytewise-defaults",
+        feature = "slice16-defaults"
+        ))]{
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            feature = "bytewise-defaults",
-            not(feature = "slice16-defaults")
+        feature = "notable-defaults",
+        feature = "bytewise-defaults",
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+        feature = "notable-defaults",
+        not(feature = "bytewise-defaults"),
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+        feature = "notable-defaults",
+        not(feature = "bytewise-defaults"),
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            feature = "bytewise-defaults",
-            feature = "slice16-defaults"
+        not(feature = "notable-defaults"),
+        feature = "bytewise-defaults",
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(256 * 4, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            feature = "bytewise-defaults",
-            not(feature = "slice16-defaults")
+        not(feature = "notable-defaults"),
+        feature = "bytewise-defaults",
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(256 * 4, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+        not(feature = "notable-defaults"),
+        not(feature = "bytewise-defaults"),
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(256 * 16 * 4, table_size);
+        {
+            const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+        not(feature = "notable-defaults"),
+        not(feature = "bytewise-defaults"),
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(256 * 4, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
+        let _ = TABLE_SIZE;
+        let _ = BYTES_PER_ENTRY;
     }
 
     /// Test this opitimized version against the well known implementation to ensure correctness

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -160,18 +160,9 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u32 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 4;
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        feature = "bytewise-memory-restrictions",
-        feature = "slice16-memory-restrictions"
-        ))]{
-            const EXPECTED: usize = 0;
-            let _ = EXPECTED;
-            const _: () = assert!(EXPECTED == TABLE_SIZE);
-        }
-        #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        feature = "bytewise-memory-restrictions",
-        not(feature = "slice16-memory-restrictions")
+            feature = "no-table-memory-restrictions",
+            feature = "bytewise-memory-restrictions",
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -179,9 +170,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        not(feature = "bytewise-memory-restrictions"),
-        feature = "slice16-memory-restrictions"
+            feature = "no-table-memory-restrictions",
+            feature = "bytewise-memory-restrictions",
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -189,9 +180,19 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        not(feature = "bytewise-memory-restrictions"),
-        not(feature = "slice16-memory-restrictions")
+            feature = "no-table-memory-restrictions",
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
+        ))]
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
+        #[cfg(all(
+            feature = "no-table-memory-restrictions",
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -200,9 +201,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        feature = "bytewise-memory-restrictions",
-        feature = "slice16-memory-restrictions"
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions",
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -210,9 +211,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        feature = "bytewise-memory-restrictions",
-        not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions",
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -221,9 +222,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        not(feature = "bytewise-memory-restrictions"),
-        feature = "slice16-memory-restrictions"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -232,9 +233,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        not(feature = "bytewise-memory-restrictions"),
-        not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -1,16 +1,10 @@
-#[cfg(any(
-    feature = "notable-defaults",
-    feature = "bytewise-defaults",
-    feature = "slice16-defaults"
-))]
-mod default;
-
-mod bytewise;
-mod nolookup;
-mod slice16;
-
 use crate::util::crc32;
 use crc_catalog::Algorithm;
+
+mod bytewise;
+mod default;
+mod nolookup;
+mod slice16;
 
 // init is shared between all impls
 const fn init(algorithm: &Algorithm<u32>, initial: u32) -> u32 {

--- a/src/crc32/default.rs
+++ b/src/crc32/default.rs
@@ -1,6 +1,5 @@
+use crate::crc32::{finalize, init};
 use crate::{Algorithm, Crc, Digest, Implementation};
-
-use super::{finalize, init};
 
 #[cfg(feature = "notable-defaults")]
 impl Implementation for u32 {
@@ -24,6 +23,16 @@ impl Implementation for u32 {
     type Table = [[u32; 256]; 16];
 }
 
+#[cfg(all(
+    not(feature = "notable-defaults"),
+    not(feature = "bytewise-defaults"),
+    not(feature = "slice16-defaults")
+))]
+impl Implementation for u32 {
+    type Width = u32;
+    type Table = [u32; 256];
+}
+
 impl Crc<u32> {
     pub const fn new(algorithm: &'static Algorithm<u32>) -> Self {
         #[cfg(all(
@@ -38,7 +47,16 @@ impl Crc<u32> {
         let table = crate::table::crc32_table(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(feature = "notable-defaults")]
+        #[allow(clippy::let_unit_value)]
         let table = ();
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        let table = crate::table::crc32_table(algorithm.width, algorithm.poly, algorithm.refin);
+
         Self { algorithm, table }
     }
 
@@ -66,6 +84,15 @@ impl Crc<u32> {
         #[cfg(feature = "notable-defaults")]
         {
             super::update_nolookup(crc, self.algorithm, bytes)
+        }
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        {
+            super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }
     }
 

--- a/src/crc32/default.rs
+++ b/src/crc32/default.rs
@@ -1,22 +1,22 @@
 use crate::crc32::{finalize, init};
 use crate::{Algorithm, Crc, Digest, Implementation};
 
-#[cfg(feature = "notable-defaults")]
+#[cfg(feature = "no-table-memory-restrictions")]
 impl Implementation for u32 {
     type Width = u32;
     type Table = ();
 }
 
-#[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+#[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
 impl Implementation for u32 {
     type Width = u32;
     type Table = [u32; 256];
 }
 
 #[cfg(all(
-    not(feature = "notable-defaults"),
-    not(feature = "bytewise-defaults"),
-    feature = "slice16-defaults"
+    not(feature = "no-table-memory-restrictions"),
+    not(feature = "bytewise-memory-restrictions"),
+    feature = "slice16-memory-restrictions"
 ))]
 impl Implementation for u32 {
     type Width = u32;
@@ -24,9 +24,9 @@ impl Implementation for u32 {
 }
 
 #[cfg(all(
-    not(feature = "notable-defaults"),
-    not(feature = "bytewise-defaults"),
-    not(feature = "slice16-defaults")
+    not(feature = "no-table-memory-restrictions"),
+    not(feature = "bytewise-memory-restrictions"),
+    not(feature = "slice16-memory-restrictions")
 ))]
 impl Implementation for u32 {
     type Width = u32;
@@ -36,24 +36,24 @@ impl Implementation for u32 {
 impl Crc<u32> {
     pub const fn new(algorithm: &'static Algorithm<u32>) -> Self {
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         let table =
             crate::table::crc32_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
         let table = crate::table::crc32_table(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(feature = "notable-defaults")]
+        #[cfg(feature = "no-table-memory-restrictions")]
         #[allow(clippy::let_unit_value)]
         let table = ();
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         let table = crate::table::crc32_table(algorithm.width, algorithm.poly, algorithm.refin);
 
@@ -68,28 +68,28 @@ impl Crc<u32> {
 
     const fn update(&self, crc: u32, bytes: &[u8]) -> u32 {
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(feature = "notable-defaults")]
+        #[cfg(feature = "no-table-memory-restrictions")]
         {
             super::update_nolookup(crc, self.algorithm, bytes)
         }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)

--- a/src/crc32/default.rs
+++ b/src/crc32/default.rs
@@ -1,15 +1,15 @@
 use crate::crc32::{finalize, init};
 use crate::{Algorithm, Crc, Digest, Implementation};
 
-#[cfg(feature = "no-table-memory-restrictions")]
+#[cfg(feature = "no-table-mem-limit")]
 impl Implementation for u32 {
     type Width = u32;
     type Table = ();
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    feature = "bytewise-memory-restrictions"
+    not(feature = "no-table-mem-limit"),
+    feature = "bytewise-mem-limit"
 ))]
 impl Implementation for u32 {
     type Width = u32;
@@ -17,9 +17,9 @@ impl Implementation for u32 {
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    not(feature = "bytewise-memory-restrictions"),
-    feature = "slice16-memory-restrictions"
+    not(feature = "no-table-mem-limit"),
+    not(feature = "bytewise-mem-limit"),
+    feature = "slice16-mem-limit"
 ))]
 impl Implementation for u32 {
     type Width = u32;
@@ -27,9 +27,9 @@ impl Implementation for u32 {
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    not(feature = "bytewise-memory-restrictions"),
-    not(feature = "slice16-memory-restrictions")
+    not(feature = "no-table-mem-limit"),
+    not(feature = "bytewise-mem-limit"),
+    not(feature = "slice16-mem-limit")
 ))]
 impl Implementation for u32 {
     type Width = u32;
@@ -39,27 +39,27 @@ impl Implementation for u32 {
 impl Crc<u32> {
     pub const fn new(algorithm: &'static Algorithm<u32>) -> Self {
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         let table =
             crate::table::crc32_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit"
         ))]
         let table = crate::table::crc32_table(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(feature = "no-table-memory-restrictions")]
+        #[cfg(feature = "no-table-mem-limit")]
         #[allow(clippy::let_unit_value)]
         let table = ();
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         let table = crate::table::crc32_table(algorithm.width, algorithm.poly, algorithm.refin);
 
@@ -74,31 +74,31 @@ impl Crc<u32> {
 
     const fn update(&self, crc: u32, bytes: &[u8]) -> u32 {
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit"
         ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(feature = "no-table-memory-restrictions")]
+        #[cfg(feature = "no-table-mem-limit")]
         {
             super::update_nolookup(crc, self.algorithm, bytes)
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)

--- a/src/crc32/default.rs
+++ b/src/crc32/default.rs
@@ -7,10 +7,7 @@ impl Implementation for u32 {
     type Table = ();
 }
 
-#[cfg(all(
-    not(feature = "no-table-mem-limit"),
-    feature = "bytewise-mem-limit"
-))]
+#[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
 impl Implementation for u32 {
     type Width = u32;
     type Table = [u32; 256];
@@ -46,10 +43,7 @@ impl Crc<u32> {
         let table =
             crate::table::crc32_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(
-            not(feature = "no-table-mem-limit"),
-            feature = "bytewise-mem-limit"
-        ))]
+        #[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
         let table = crate::table::crc32_table(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(feature = "no-table-mem-limit")]
@@ -82,10 +76,7 @@ impl Crc<u32> {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(all(
-            not(feature = "no-table-mem-limit"),
-            feature = "bytewise-mem-limit"
-        ))]
+        #[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }

--- a/src/crc32/default.rs
+++ b/src/crc32/default.rs
@@ -1,11 +1,44 @@
-use crate::table::crc32_table_slice_16;
-use crate::{Algorithm, Crc, Digest};
+use crate::{Algorithm, Crc, Digest, Implementation};
 
-use super::{finalize, init, update_slice16};
+use super::{finalize, init};
+
+#[cfg(feature = "notable-defaults")]
+impl Implementation for u32 {
+    type Width = u32;
+    type Table = ();
+}
+
+#[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+impl Implementation for u32 {
+    type Width = u32;
+    type Table = [u32; 256];
+}
+
+#[cfg(all(
+    not(feature = "notable-defaults"),
+    not(feature = "bytewise-defaults"),
+    feature = "slice16-defaults"
+))]
+impl Implementation for u32 {
+    type Width = u32;
+    type Table = [[u32; 256]; 16];
+}
 
 impl Crc<u32> {
     pub const fn new(algorithm: &'static Algorithm<u32>) -> Self {
-        let table = crc32_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        let table =
+            crate::table::crc32_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
+
+        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        let table = crate::table::crc32_table(algorithm.width, algorithm.poly, algorithm.refin);
+
+        #[cfg(feature = "notable-defaults")]
+        let table = ();
         Self { algorithm, table }
     }
 
@@ -16,7 +49,24 @@ impl Crc<u32> {
     }
 
     const fn update(&self, crc: u32, bytes: &[u8]) -> u32 {
-        update_slice16(crc, self.algorithm.refin, &self.table, bytes)
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        {
+            super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
+        }
+
+        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        {
+            super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
+        }
+
+        #[cfg(feature = "notable-defaults")]
+        {
+            super::update_nolookup(crc, self.algorithm, bytes)
+        }
     }
 
     pub const fn digest(&self) -> Digest<u32> {

--- a/src/crc32/default.rs
+++ b/src/crc32/default.rs
@@ -7,7 +7,10 @@ impl Implementation for u32 {
     type Table = ();
 }
 
-#[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+#[cfg(all(
+    not(feature = "no-table-memory-restrictions"),
+    feature = "bytewise-memory-restrictions"
+))]
 impl Implementation for u32 {
     type Width = u32;
     type Table = [u32; 256];
@@ -43,7 +46,10 @@ impl Crc<u32> {
         let table =
             crate::table::crc32_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+        #[cfg(all(
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions"
+        ))]
         let table = crate::table::crc32_table(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(feature = "no-table-memory-restrictions")]
@@ -76,7 +82,10 @@ impl Crc<u32> {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+        #[cfg(all(
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions"
+        ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -162,18 +162,9 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u64 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 8;
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        feature = "bytewise-memory-restrictions",
-        feature = "slice16-memory-restrictions"
-        ))]{
-            const EXPECTED: usize = 0;
-            let _ = EXPECTED;
-            const _: () = assert!(EXPECTED == TABLE_SIZE);
-        }
-        #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        feature = "bytewise-memory-restrictions",
-        not(feature = "slice16-memory-restrictions")
+            feature = "no-table-memory-restrictions",
+            feature = "bytewise-memory-restrictions",
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -181,9 +172,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        not(feature = "bytewise-memory-restrictions"),
-        feature = "slice16-memory-restrictions"
+            feature = "no-table-memory-restrictions",
+            feature = "bytewise-memory-restrictions",
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -191,9 +182,19 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        not(feature = "bytewise-memory-restrictions"),
-        not(feature = "slice16-memory-restrictions")
+            feature = "no-table-memory-restrictions",
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
+        ))]
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
+        #[cfg(all(
+            feature = "no-table-memory-restrictions",
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -202,9 +203,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        feature = "bytewise-memory-restrictions",
-        feature = "slice16-memory-restrictions"
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions",
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -212,9 +213,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        feature = "bytewise-memory-restrictions",
-        not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions",
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -223,9 +224,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        not(feature = "bytewise-memory-restrictions"),
-        feature = "slice16-memory-restrictions"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -234,9 +235,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        not(feature = "bytewise-memory-restrictions"),
-        not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -1,15 +1,8 @@
+use crate::util::crc64;
 use crc_catalog::Algorithm;
 
-use crate::util::crc64;
-
-#[cfg(any(
-    feature = "notable-defaults",
-    feature = "bytewise-defaults",
-    feature = "slice16-defaults"
-))]
-mod default;
-
 mod bytewise;
+mod default;
 mod nolookup;
 mod slice16;
 

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -2,8 +2,14 @@ use crc_catalog::Algorithm;
 
 use crate::util::crc64;
 
-mod bytewise;
+#[cfg(any(
+    feature = "notable-defaults",
+    feature = "bytewise-defaults",
+    feature = "slice16-defaults"
+))]
 mod default;
+
+mod bytewise;
 mod nolookup;
 mod slice16;
 

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -162,18 +162,18 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u64 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 8;
         #[cfg(all(
-        feature = "notable-defaults",
-        feature = "bytewise-defaults",
-        feature = "slice16-defaults"
+        feature = "no-table-memory-restrictions",
+        feature = "bytewise-memory-restrictions",
+        feature = "slice16-memory-restrictions"
         ))]{
             const EXPECTED: usize = 0;
             let _ = EXPECTED;
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        feature = "bytewise-defaults",
-        not(feature = "slice16-defaults")
+        feature = "no-table-memory-restrictions",
+        feature = "bytewise-memory-restrictions",
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -181,9 +181,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        not(feature = "bytewise-defaults"),
-        feature = "slice16-defaults"
+        feature = "no-table-memory-restrictions",
+        not(feature = "bytewise-memory-restrictions"),
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -191,9 +191,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        not(feature = "bytewise-defaults"),
-        not(feature = "slice16-defaults")
+        feature = "no-table-memory-restrictions",
+        not(feature = "bytewise-memory-restrictions"),
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -202,9 +202,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        feature = "bytewise-defaults",
-        feature = "slice16-defaults"
+        not(feature = "no-table-memory-restrictions"),
+        feature = "bytewise-memory-restrictions",
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -212,9 +212,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        feature = "bytewise-defaults",
-        not(feature = "slice16-defaults")
+        not(feature = "no-table-memory-restrictions"),
+        feature = "bytewise-memory-restrictions",
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -223,9 +223,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        not(feature = "bytewise-defaults"),
-        feature = "slice16-defaults"
+        not(feature = "no-table-memory-restrictions"),
+        not(feature = "bytewise-memory-restrictions"),
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -234,9 +234,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        not(feature = "bytewise-defaults"),
-        not(feature = "slice16-defaults")
+        not(feature = "no-table-memory-restrictions"),
+        not(feature = "bytewise-memory-restrictions"),
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -247,7 +247,7 @@ mod test {
         let _ = BYTES_PER_ENTRY;
     }
 
-    /// Test this opitimized version against the well known implementation to ensure correctness
+    /// Test this optimized version against the well known implementation to ensure correctness
     #[test]
     fn correctness() {
         let data: &[&str] = &[

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -154,8 +154,64 @@ const fn update_slice16(
 
 #[cfg(test)]
 mod test {
-    use crate::{Bytewise, Crc, NoTable, Slice16};
+    use crate::{Bytewise, Crc, Implementation, NoTable, Slice16};
     use crc_catalog::{Algorithm, CRC_64_ECMA_182};
+
+    #[test]
+    fn default_table_size() {
+        let table_size = core::mem::size_of::<<u64 as Implementation>::Table>();
+        #[cfg(all(
+            feature = "notable-defaults",
+            feature = "bytewise-defaults",
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            feature = "bytewise-defaults",
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(0, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            feature = "bytewise-defaults",
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(256 * 8, table_size);
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            feature = "bytewise-defaults",
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(256 * 8, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(256 * 16 * 8, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(256 * 8, table_size);
+    }
 
     /// Test this opitimized version against the well known implementation to ensure correctness
     #[test]

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -162,9 +162,9 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u64 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 8;
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            feature = "bytewise-memory-restrictions",
-            feature = "slice16-memory-restrictions"
+            feature = "no-table-mem-limit",
+            feature = "bytewise-mem-limit",
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -172,9 +172,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            feature = "bytewise-memory-restrictions",
-            not(feature = "slice16-memory-restrictions")
+            feature = "no-table-mem-limit",
+            feature = "bytewise-mem-limit",
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -182,9 +182,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            feature = "no-table-mem-limit",
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -192,9 +192,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            feature = "no-table-mem-limit",
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -203,9 +203,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions",
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit",
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -213,9 +213,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions",
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit",
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -224,9 +224,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -235,9 +235,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -159,58 +159,92 @@ mod test {
 
     #[test]
     fn default_table_size() {
-        let table_size = core::mem::size_of::<<u64 as Implementation>::Table>();
+        const TABLE_SIZE: usize = core::mem::size_of::<<u64 as Implementation>::Table>();
+        const BYTES_PER_ENTRY: usize = 8;
         #[cfg(all(
-            feature = "notable-defaults",
-            feature = "bytewise-defaults",
-            feature = "slice16-defaults"
-        ))]
-        assert_eq!(0, table_size);
+        feature = "notable-defaults",
+        feature = "bytewise-defaults",
+        feature = "slice16-defaults"
+        ))]{
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            feature = "bytewise-defaults",
-            not(feature = "slice16-defaults")
+        feature = "notable-defaults",
+        feature = "bytewise-defaults",
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+        feature = "notable-defaults",
+        not(feature = "bytewise-defaults"),
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+        feature = "notable-defaults",
+        not(feature = "bytewise-defaults"),
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            feature = "bytewise-defaults",
-            feature = "slice16-defaults"
+        not(feature = "notable-defaults"),
+        feature = "bytewise-defaults",
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(256 * 8, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            feature = "bytewise-defaults",
-            not(feature = "slice16-defaults")
+        not(feature = "notable-defaults"),
+        feature = "bytewise-defaults",
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(256 * 8, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+        not(feature = "notable-defaults"),
+        not(feature = "bytewise-defaults"),
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(256 * 16 * 8, table_size);
+        {
+            const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+        not(feature = "notable-defaults"),
+        not(feature = "bytewise-defaults"),
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(256 * 8, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
+        let _ = TABLE_SIZE;
+        let _ = BYTES_PER_ENTRY;
     }
 
     /// Test this opitimized version against the well known implementation to ensure correctness

--- a/src/crc64/default.rs
+++ b/src/crc64/default.rs
@@ -1,22 +1,22 @@
 use crate::crc64::{finalize, init};
 use crate::{Algorithm, Crc, Digest, Implementation};
 
-#[cfg(feature = "notable-defaults")]
+#[cfg(feature = "no-table-memory-restrictions")]
 impl Implementation for u64 {
     type Width = u64;
     type Table = ();
 }
 
-#[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+#[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
 impl Implementation for u64 {
     type Width = u64;
     type Table = [u64; 256];
 }
 
 #[cfg(all(
-    not(feature = "notable-defaults"),
-    not(feature = "bytewise-defaults"),
-    feature = "slice16-defaults"
+    not(feature = "no-table-memory-restrictions"),
+    not(feature = "bytewise-memory-restrictions"),
+    feature = "slice16-memory-restrictions"
 ))]
 impl Implementation for u64 {
     type Width = u64;
@@ -24,9 +24,9 @@ impl Implementation for u64 {
 }
 
 #[cfg(all(
-    not(feature = "notable-defaults"),
-    not(feature = "bytewise-defaults"),
-    not(feature = "slice16-defaults")
+    not(feature = "no-table-memory-restrictions"),
+    not(feature = "bytewise-memory-restrictions"),
+    not(feature = "slice16-memory-restrictions")
 ))]
 impl Implementation for u64 {
     type Width = u64;
@@ -36,24 +36,24 @@ impl Implementation for u64 {
 impl Crc<u64> {
     pub const fn new(algorithm: &'static Algorithm<u64>) -> Self {
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         let table =
             crate::table::crc64_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
         let table = crate::table::crc64_table(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(feature = "notable-defaults")]
+        #[cfg(feature = "no-table-memory-restrictions")]
         #[allow(clippy::let_unit_value)]
         let table = ();
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         let table = crate::table::crc64_table(algorithm.width, algorithm.poly, algorithm.refin);
 
@@ -68,28 +68,28 @@ impl Crc<u64> {
 
     const fn update(&self, crc: u64, bytes: &[u8]) -> u64 {
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(feature = "notable-defaults")]
+        #[cfg(feature = "no-table-memory-restrictions")]
         {
             super::update_nolookup(crc, self.algorithm, bytes)
         }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)

--- a/src/crc64/default.rs
+++ b/src/crc64/default.rs
@@ -1,15 +1,15 @@
 use crate::crc64::{finalize, init};
 use crate::{Algorithm, Crc, Digest, Implementation};
 
-#[cfg(feature = "no-table-memory-restrictions")]
+#[cfg(feature = "no-table-mem-limit")]
 impl Implementation for u64 {
     type Width = u64;
     type Table = ();
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    feature = "bytewise-memory-restrictions"
+    not(feature = "no-table-mem-limit"),
+    feature = "bytewise-mem-limit"
 ))]
 impl Implementation for u64 {
     type Width = u64;
@@ -17,9 +17,9 @@ impl Implementation for u64 {
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    not(feature = "bytewise-memory-restrictions"),
-    feature = "slice16-memory-restrictions"
+    not(feature = "no-table-mem-limit"),
+    not(feature = "bytewise-mem-limit"),
+    feature = "slice16-mem-limit"
 ))]
 impl Implementation for u64 {
     type Width = u64;
@@ -27,9 +27,9 @@ impl Implementation for u64 {
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    not(feature = "bytewise-memory-restrictions"),
-    not(feature = "slice16-memory-restrictions")
+    not(feature = "no-table-mem-limit"),
+    not(feature = "bytewise-mem-limit"),
+    not(feature = "slice16-mem-limit")
 ))]
 impl Implementation for u64 {
     type Width = u64;
@@ -39,27 +39,27 @@ impl Implementation for u64 {
 impl Crc<u64> {
     pub const fn new(algorithm: &'static Algorithm<u64>) -> Self {
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         let table =
             crate::table::crc64_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit"
         ))]
         let table = crate::table::crc64_table(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(feature = "no-table-memory-restrictions")]
+        #[cfg(feature = "no-table-mem-limit")]
         #[allow(clippy::let_unit_value)]
         let table = ();
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         let table = crate::table::crc64_table(algorithm.width, algorithm.poly, algorithm.refin);
 
@@ -74,31 +74,31 @@ impl Crc<u64> {
 
     const fn update(&self, crc: u64, bytes: &[u8]) -> u64 {
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit"
         ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(feature = "no-table-memory-restrictions")]
+        #[cfg(feature = "no-table-mem-limit")]
         {
             super::update_nolookup(crc, self.algorithm, bytes)
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)

--- a/src/crc64/default.rs
+++ b/src/crc64/default.rs
@@ -7,7 +7,10 @@ impl Implementation for u64 {
     type Table = ();
 }
 
-#[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+#[cfg(all(
+    not(feature = "no-table-memory-restrictions"),
+    feature = "bytewise-memory-restrictions"
+))]
 impl Implementation for u64 {
     type Width = u64;
     type Table = [u64; 256];
@@ -43,7 +46,10 @@ impl Crc<u64> {
         let table =
             crate::table::crc64_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+        #[cfg(all(
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions"
+        ))]
         let table = crate::table::crc64_table(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(feature = "no-table-memory-restrictions")]
@@ -76,7 +82,10 @@ impl Crc<u64> {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+        #[cfg(all(
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions"
+        ))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }

--- a/src/crc64/default.rs
+++ b/src/crc64/default.rs
@@ -7,10 +7,7 @@ impl Implementation for u64 {
     type Table = ();
 }
 
-#[cfg(all(
-    not(feature = "no-table-mem-limit"),
-    feature = "bytewise-mem-limit"
-))]
+#[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
 impl Implementation for u64 {
     type Width = u64;
     type Table = [u64; 256];
@@ -46,10 +43,7 @@ impl Crc<u64> {
         let table =
             crate::table::crc64_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(
-            not(feature = "no-table-mem-limit"),
-            feature = "bytewise-mem-limit"
-        ))]
+        #[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
         let table = crate::table::crc64_table(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(feature = "no-table-mem-limit")]
@@ -82,10 +76,7 @@ impl Crc<u64> {
             super::update_slice16(crc, self.algorithm.refin, &self.table, bytes)
         }
 
-        #[cfg(all(
-            not(feature = "no-table-mem-limit"),
-            feature = "bytewise-mem-limit"
-        ))]
+        #[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
         {
             super::update_bytewise(crc, self.algorithm.refin, &self.table, bytes)
         }

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -88,8 +88,64 @@ const fn update_slice16(mut crc: u8, table: &[[u8; 256]; 16], bytes: &[u8]) -> u
 
 #[cfg(test)]
 mod test {
-    use crate::{Bytewise, Crc, NoTable, Slice16};
+    use crate::{Bytewise, Crc, Implementation, NoTable, Slice16};
     use crc_catalog::{Algorithm, CRC_8_BLUETOOTH};
+
+    #[test]
+    fn default_table_size() {
+        let table_size = core::mem::size_of::<<u8 as Implementation>::Table>();
+        #[cfg(all(
+            feature = "notable-defaults",
+            feature = "bytewise-defaults",
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            feature = "bytewise-defaults",
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(0, table_size);
+        #[cfg(all(
+            feature = "notable-defaults",
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(0, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            feature = "bytewise-defaults",
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(256 * 1, table_size);
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            feature = "bytewise-defaults",
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(256 * 1, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        assert_eq!(256 * 16 * 1, table_size);
+
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            not(feature = "slice16-defaults")
+        ))]
+        assert_eq!(256 * 1, table_size);
+    }
 
     /// Test this opitimized version against the well known implementation to ensure correctness
     #[test]

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -1,8 +1,14 @@
 use crate::util::crc8;
 use crc_catalog::Algorithm;
 
-mod bytewise;
+#[cfg(any(
+    feature = "notable-defaults",
+    feature = "bytewise-defaults",
+    feature = "slice16-defaults"
+))]
 mod default;
+
+mod bytewise;
 mod nolookup;
 mod slice16;
 

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -93,58 +93,92 @@ mod test {
 
     #[test]
     fn default_table_size() {
-        let table_size = core::mem::size_of::<<u8 as Implementation>::Table>();
+        const TABLE_SIZE: usize = core::mem::size_of::<<u8 as Implementation>::Table>();
+        const BYTES_PER_ENTRY: usize = 1;
         #[cfg(all(
-            feature = "notable-defaults",
-            feature = "bytewise-defaults",
-            feature = "slice16-defaults"
-        ))]
-        assert_eq!(0, table_size);
+        feature = "notable-defaults",
+        feature = "bytewise-defaults",
+        feature = "slice16-defaults"
+        ))]{
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            feature = "bytewise-defaults",
-            not(feature = "slice16-defaults")
+        feature = "notable-defaults",
+        feature = "bytewise-defaults",
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+        feature = "notable-defaults",
+        not(feature = "bytewise-defaults"),
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            feature = "notable-defaults",
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+        feature = "notable-defaults",
+        not(feature = "bytewise-defaults"),
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(0, table_size);
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            feature = "bytewise-defaults",
-            feature = "slice16-defaults"
+        not(feature = "notable-defaults"),
+        feature = "bytewise-defaults",
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(256 * 1, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            feature = "bytewise-defaults",
-            not(feature = "slice16-defaults")
+        not(feature = "notable-defaults"),
+        feature = "bytewise-defaults",
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(256 * 1, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+        not(feature = "notable-defaults"),
+        not(feature = "bytewise-defaults"),
+        feature = "slice16-defaults"
         ))]
-        assert_eq!(256 * 16 * 1, table_size);
+        {
+            const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+        not(feature = "notable-defaults"),
+        not(feature = "bytewise-defaults"),
+        not(feature = "slice16-defaults")
         ))]
-        assert_eq!(256 * 1, table_size);
+        {
+            const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
+        let _ = TABLE_SIZE;
+        let _ = BYTES_PER_ENTRY;
     }
 
     /// Test this opitimized version against the well known implementation to ensure correctness

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -96,9 +96,9 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u8 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 1;
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            feature = "bytewise-memory-restrictions",
-            feature = "slice16-memory-restrictions"
+            feature = "no-table-mem-limit",
+            feature = "bytewise-mem-limit",
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -106,9 +106,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            feature = "bytewise-memory-restrictions",
-            not(feature = "slice16-memory-restrictions")
+            feature = "no-table-mem-limit",
+            feature = "bytewise-mem-limit",
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -116,9 +116,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            feature = "no-table-mem-limit",
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -126,9 +126,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            feature = "no-table-memory-restrictions",
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            feature = "no-table-mem-limit",
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -137,9 +137,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions",
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit",
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -147,9 +147,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions",
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit",
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -158,9 +158,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -169,9 +169,9 @@ mod test {
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -1,14 +1,8 @@
 use crate::util::crc8;
 use crc_catalog::Algorithm;
 
-#[cfg(any(
-    feature = "notable-defaults",
-    feature = "bytewise-defaults",
-    feature = "slice16-defaults"
-))]
-mod default;
-
 mod bytewise;
+mod default;
 mod nolookup;
 mod slice16;
 

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -96,18 +96,18 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u8 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 1;
         #[cfg(all(
-        feature = "notable-defaults",
-        feature = "bytewise-defaults",
-        feature = "slice16-defaults"
+        feature = "no-table-memory-restrictions",
+        feature = "bytewise-memory-restrictions",
+        feature = "slice16-memory-restrictions"
         ))]{
             const EXPECTED: usize = 0;
             let _ = EXPECTED;
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        feature = "bytewise-defaults",
-        not(feature = "slice16-defaults")
+        feature = "no-table-memory-restrictions",
+        feature = "bytewise-memory-restrictions",
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -115,9 +115,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        not(feature = "bytewise-defaults"),
-        feature = "slice16-defaults"
+        feature = "no-table-memory-restrictions",
+        not(feature = "bytewise-memory-restrictions"),
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -125,9 +125,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "notable-defaults",
-        not(feature = "bytewise-defaults"),
-        not(feature = "slice16-defaults")
+        feature = "no-table-memory-restrictions",
+        not(feature = "bytewise-memory-restrictions"),
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -136,9 +136,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        feature = "bytewise-defaults",
-        feature = "slice16-defaults"
+        not(feature = "no-table-memory-restrictions"),
+        feature = "bytewise-memory-restrictions",
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -146,9 +146,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        feature = "bytewise-defaults",
-        not(feature = "slice16-defaults")
+        not(feature = "no-table-memory-restrictions"),
+        feature = "bytewise-memory-restrictions",
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -157,9 +157,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        not(feature = "bytewise-defaults"),
-        feature = "slice16-defaults"
+        not(feature = "no-table-memory-restrictions"),
+        not(feature = "bytewise-memory-restrictions"),
+        feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -168,9 +168,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "notable-defaults"),
-        not(feature = "bytewise-defaults"),
-        not(feature = "slice16-defaults")
+        not(feature = "no-table-memory-restrictions"),
+        not(feature = "bytewise-memory-restrictions"),
+        not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -181,7 +181,7 @@ mod test {
         let _ = BYTES_PER_ENTRY;
     }
 
-    /// Test this opitimized version against the well known implementation to ensure correctness
+    /// Test this optimized version against the well known implementation to ensure correctness
     #[test]
     fn correctness() {
         let data: &[&str] = &[

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -96,18 +96,9 @@ mod test {
         const TABLE_SIZE: usize = core::mem::size_of::<<u8 as Implementation>::Table>();
         const BYTES_PER_ENTRY: usize = 1;
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        feature = "bytewise-memory-restrictions",
-        feature = "slice16-memory-restrictions"
-        ))]{
-            const EXPECTED: usize = 0;
-            let _ = EXPECTED;
-            const _: () = assert!(EXPECTED == TABLE_SIZE);
-        }
-        #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        feature = "bytewise-memory-restrictions",
-        not(feature = "slice16-memory-restrictions")
+            feature = "no-table-memory-restrictions",
+            feature = "bytewise-memory-restrictions",
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 0;
@@ -115,9 +106,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        not(feature = "bytewise-memory-restrictions"),
-        feature = "slice16-memory-restrictions"
+            feature = "no-table-memory-restrictions",
+            feature = "bytewise-memory-restrictions",
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -125,9 +116,19 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        feature = "no-table-memory-restrictions",
-        not(feature = "bytewise-memory-restrictions"),
-        not(feature = "slice16-memory-restrictions")
+            feature = "no-table-memory-restrictions",
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
+        ))]
+        {
+            const EXPECTED: usize = 0;
+            let _ = EXPECTED;
+            const _: () = assert!(EXPECTED == TABLE_SIZE);
+        }
+        #[cfg(all(
+            feature = "no-table-memory-restrictions",
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 0;
@@ -136,9 +137,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        feature = "bytewise-memory-restrictions",
-        feature = "slice16-memory-restrictions"
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions",
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -146,9 +147,9 @@ mod test {
             const _: () = assert!(EXPECTED == TABLE_SIZE);
         }
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        feature = "bytewise-memory-restrictions",
-        not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions",
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;
@@ -157,9 +158,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        not(feature = "bytewise-memory-restrictions"),
-        feature = "slice16-memory-restrictions"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         {
             const EXPECTED: usize = 256 * 16 * BYTES_PER_ENTRY;
@@ -168,9 +169,9 @@ mod test {
         }
 
         #[cfg(all(
-        not(feature = "no-table-memory-restrictions"),
-        not(feature = "bytewise-memory-restrictions"),
-        not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             const EXPECTED: usize = 256 * BYTES_PER_ENTRY;

--- a/src/crc8/default.rs
+++ b/src/crc8/default.rs
@@ -1,22 +1,22 @@
 use crate::crc8::{finalize, init};
 use crate::{Algorithm, Crc, Digest, Implementation};
 
-#[cfg(feature = "notable-defaults")]
+#[cfg(feature = "no-table-memory-restrictions")]
 impl Implementation for u8 {
     type Width = u8;
     type Table = ();
 }
 
-#[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+#[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
 impl Implementation for u8 {
     type Width = u8;
     type Table = [u8; 256];
 }
 
 #[cfg(all(
-    not(feature = "notable-defaults"),
-    not(feature = "bytewise-defaults"),
-    feature = "slice16-defaults"
+    not(feature = "no-table-memory-restrictions"),
+    not(feature = "bytewise-memory-restrictions"),
+    feature = "slice16-memory-restrictions"
 ))]
 impl Implementation for u8 {
     type Width = u8;
@@ -24,9 +24,9 @@ impl Implementation for u8 {
 }
 
 #[cfg(all(
-    not(feature = "notable-defaults"),
-    not(feature = "bytewise-defaults"),
-    not(feature = "slice16-defaults")
+    not(feature = "no-table-memory-restrictions"),
+    not(feature = "bytewise-memory-restrictions"),
+    not(feature = "slice16-memory-restrictions")
 ))]
 impl Implementation for u8 {
     type Width = u8;
@@ -36,24 +36,24 @@ impl Implementation for u8 {
 impl Crc<u8> {
     pub const fn new(algorithm: &'static Algorithm<u8>) -> Self {
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         let table =
             crate::table::crc8_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
         let table = crate::table::crc8_table(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(feature = "notable-defaults")]
+        #[cfg(feature = "no-table-memory-restrictions")]
         #[allow(clippy::let_unit_value)]
         let table = ();
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         let table = crate::table::crc8_table(algorithm.width, algorithm.poly, algorithm.refin);
 
@@ -68,28 +68,28 @@ impl Crc<u8> {
 
     const fn update(&self, crc: u8, bytes: &[u8]) -> u8 {
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            feature = "slice16-defaults"
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            feature = "slice16-memory-restrictions"
         ))]
         {
             super::update_slice16(crc, &self.table, bytes)
         }
 
-        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
         {
             super::update_bytewise(crc, &self.table, bytes)
         }
 
-        #[cfg(feature = "notable-defaults")]
+        #[cfg(feature = "no-table-memory-restrictions")]
         {
             super::update_nolookup(crc, self.algorithm, bytes)
         }
 
         #[cfg(all(
-            not(feature = "notable-defaults"),
-            not(feature = "bytewise-defaults"),
-            not(feature = "slice16-defaults")
+            not(feature = "no-table-memory-restrictions"),
+            not(feature = "bytewise-memory-restrictions"),
+            not(feature = "slice16-memory-restrictions")
         ))]
         {
             super::update_bytewise(crc, &self.table, bytes)

--- a/src/crc8/default.rs
+++ b/src/crc8/default.rs
@@ -7,7 +7,10 @@ impl Implementation for u8 {
     type Table = ();
 }
 
-#[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+#[cfg(all(
+    not(feature = "no-table-memory-restrictions"),
+    feature = "bytewise-memory-restrictions"
+))]
 impl Implementation for u8 {
     type Width = u8;
     type Table = [u8; 256];
@@ -43,7 +46,10 @@ impl Crc<u8> {
         let table =
             crate::table::crc8_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+        #[cfg(all(
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions"
+        ))]
         let table = crate::table::crc8_table(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(feature = "no-table-memory-restrictions")]
@@ -76,7 +82,10 @@ impl Crc<u8> {
             super::update_slice16(crc, &self.table, bytes)
         }
 
-        #[cfg(all(not(feature = "no-table-memory-restrictions"), feature = "bytewise-memory-restrictions"))]
+        #[cfg(all(
+            not(feature = "no-table-memory-restrictions"),
+            feature = "bytewise-memory-restrictions"
+        ))]
         {
             super::update_bytewise(crc, &self.table, bytes)
         }

--- a/src/crc8/default.rs
+++ b/src/crc8/default.rs
@@ -1,12 +1,45 @@
 use crate::crc8::{finalize, init};
-use crate::table::crc8_table_slice_16;
+use crate::Implementation;
 use crate::{Algorithm, Crc, Digest};
 
-use super::update_slice16;
+#[cfg(feature = "notable-defaults")]
+impl Implementation for u8 {
+    type Width = u8;
+    type Table = ();
+}
+
+#[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+impl Implementation for u8 {
+    type Width = u8;
+    type Table = [u8; 256];
+}
+
+#[cfg(all(
+    not(feature = "notable-defaults"),
+    not(feature = "bytewise-defaults"),
+    feature = "slice16-defaults"
+))]
+impl Implementation for u8 {
+    type Width = u8;
+    type Table = [[u8; 256]; 16];
+}
 
 impl Crc<u8> {
     pub const fn new(algorithm: &'static Algorithm<u8>) -> Self {
-        let table = crc8_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        let table =
+            crate::table::crc8_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
+
+        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        let table = crate::table::crc8_table(algorithm.width, algorithm.poly, algorithm.refin);
+
+        #[cfg(feature = "notable-defaults")]
+        let table = ();
+
         Self { algorithm, table }
     }
 
@@ -17,7 +50,24 @@ impl Crc<u8> {
     }
 
     const fn update(&self, crc: u8, bytes: &[u8]) -> u8 {
-        update_slice16(crc, &self.table, bytes)
+        #[cfg(all(
+            not(feature = "notable-defaults"),
+            not(feature = "bytewise-defaults"),
+            feature = "slice16-defaults"
+        ))]
+        {
+            super::update_slice16(crc, &self.table, bytes)
+        }
+
+        #[cfg(all(not(feature = "notable-defaults"), feature = "bytewise-defaults"))]
+        {
+            super::update_bytewise(crc, &self.table, bytes)
+        }
+
+        #[cfg(feature = "notable-defaults")]
+        {
+            super::update_nolookup(crc, self.algorithm, bytes)
+        }
     }
 
     pub const fn digest(&self) -> Digest<u8> {

--- a/src/crc8/default.rs
+++ b/src/crc8/default.rs
@@ -1,15 +1,15 @@
 use crate::crc8::{finalize, init};
 use crate::{Algorithm, Crc, Digest, Implementation};
 
-#[cfg(feature = "no-table-memory-restrictions")]
+#[cfg(feature = "no-table-mem-limit")]
 impl Implementation for u8 {
     type Width = u8;
     type Table = ();
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    feature = "bytewise-memory-restrictions"
+    not(feature = "no-table-mem-limit"),
+    feature = "bytewise-mem-limit"
 ))]
 impl Implementation for u8 {
     type Width = u8;
@@ -17,9 +17,9 @@ impl Implementation for u8 {
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    not(feature = "bytewise-memory-restrictions"),
-    feature = "slice16-memory-restrictions"
+    not(feature = "no-table-mem-limit"),
+    not(feature = "bytewise-mem-limit"),
+    feature = "slice16-mem-limit"
 ))]
 impl Implementation for u8 {
     type Width = u8;
@@ -27,9 +27,9 @@ impl Implementation for u8 {
 }
 
 #[cfg(all(
-    not(feature = "no-table-memory-restrictions"),
-    not(feature = "bytewise-memory-restrictions"),
-    not(feature = "slice16-memory-restrictions")
+    not(feature = "no-table-mem-limit"),
+    not(feature = "bytewise-mem-limit"),
+    not(feature = "slice16-mem-limit")
 ))]
 impl Implementation for u8 {
     type Width = u8;
@@ -39,27 +39,27 @@ impl Implementation for u8 {
 impl Crc<u8> {
     pub const fn new(algorithm: &'static Algorithm<u8>) -> Self {
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         let table =
             crate::table::crc8_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit"
         ))]
         let table = crate::table::crc8_table(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(feature = "no-table-memory-restrictions")]
+        #[cfg(feature = "no-table-mem-limit")]
         #[allow(clippy::let_unit_value)]
         let table = ();
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         let table = crate::table::crc8_table(algorithm.width, algorithm.poly, algorithm.refin);
 
@@ -74,31 +74,31 @@ impl Crc<u8> {
 
     const fn update(&self, crc: u8, bytes: &[u8]) -> u8 {
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            feature = "slice16-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            feature = "slice16-mem-limit"
         ))]
         {
             super::update_slice16(crc, &self.table, bytes)
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            feature = "bytewise-memory-restrictions"
+            not(feature = "no-table-mem-limit"),
+            feature = "bytewise-mem-limit"
         ))]
         {
             super::update_bytewise(crc, &self.table, bytes)
         }
 
-        #[cfg(feature = "no-table-memory-restrictions")]
+        #[cfg(feature = "no-table-mem-limit")]
         {
             super::update_nolookup(crc, self.algorithm, bytes)
         }
 
         #[cfg(all(
-            not(feature = "no-table-memory-restrictions"),
-            not(feature = "bytewise-memory-restrictions"),
-            not(feature = "slice16-memory-restrictions")
+            not(feature = "no-table-mem-limit"),
+            not(feature = "bytewise-mem-limit"),
+            not(feature = "slice16-mem-limit")
         ))]
         {
             super::update_bytewise(crc, &self.table, bytes)

--- a/src/crc8/default.rs
+++ b/src/crc8/default.rs
@@ -7,10 +7,7 @@ impl Implementation for u8 {
     type Table = ();
 }
 
-#[cfg(all(
-    not(feature = "no-table-mem-limit"),
-    feature = "bytewise-mem-limit"
-))]
+#[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
 impl Implementation for u8 {
     type Width = u8;
     type Table = [u8; 256];
@@ -46,10 +43,7 @@ impl Crc<u8> {
         let table =
             crate::table::crc8_table_slice_16(algorithm.width, algorithm.poly, algorithm.refin);
 
-        #[cfg(all(
-            not(feature = "no-table-mem-limit"),
-            feature = "bytewise-mem-limit"
-        ))]
+        #[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
         let table = crate::table::crc8_table(algorithm.width, algorithm.poly, algorithm.refin);
 
         #[cfg(feature = "no-table-mem-limit")]
@@ -82,10 +76,7 @@ impl Crc<u8> {
             super::update_slice16(crc, &self.table, bytes)
         }
 
-        #[cfg(all(
-            not(feature = "no-table-mem-limit"),
-            feature = "bytewise-mem-limit"
-        ))]
+        #[cfg(all(not(feature = "no-table-mem-limit"), feature = "bytewise-mem-limit"))]
         {
             super::update_bytewise(crc, &self.table, bytes)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,6 @@ pub trait Implementation: private::Sealed {
     type Table;
 }
 
-impl Implementation for u128 {
-    type Width = u128;
-    type Table = [u128; 256];
-}
-
 /// Crc with pluggable implementations ([Nolookup], [Bytewise], [Slice16]).
 /// To choose the default implementation, use the [Width] directly (e.g. `Crc<u32>`).
 pub struct Crc<I: Implementation> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,6 @@ pub trait Implementation: private::Sealed {
     type Table;
 }
 
-impl Implementation for u64 {
-    type Width = u64;
-    type Table = [[u64; 256]; 16];
-}
-
 impl Implementation for u128 {
     type Width = u128;
     type Table = [u128; 256];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,6 @@ pub trait Implementation: private::Sealed {
     type Table;
 }
 
-impl Implementation for u32 {
-    type Width = u32;
-    type Table = [[u32; 256]; 16];
-}
-
 impl Implementation for u64 {
     type Width = u64;
     type Table = [[u64; 256]; 16];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,6 @@ pub trait Implementation: private::Sealed {
     type Table;
 }
 
-impl Implementation for u16 {
-    type Width = u16;
-    type Table = [[u16; 256]; 16];
-}
-
 impl Implementation for u32 {
     type Width = u32;
     type Table = [[u32; 256]; 16];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,6 @@ pub trait Implementation: private::Sealed {
     type Table;
 }
 
-impl Implementation for u8 {
-    type Width = u8;
-    type Table = [[u8; 256]; 16];
-}
-
 impl Implementation for u16 {
     type Width = u16;
     type Table = [[u16; 256]; 16];

--- a/tests/test_under_all_feature_combinations.sh
+++ b/tests/test_under_all_feature_combinations.sh
@@ -3,13 +3,13 @@ set -ex
 cargo test
 cargo test --no-default-features
 
-cargo test --features slice16-memory-restrictions
-cargo test --features bytewise-memory-restrictions
-cargo test --features no-table-memory-restrictions
+cargo test --features slice16-mem-limit
+cargo test --features bytewise-mem-limit
+cargo test --features no-table-mem-limit
 
-cargo test --features bytewise-memory-restrictions,slice16-memory-restrictions
-cargo test --features no-table-memory-restrictions,bytewise-memory-restrictions
-cargo test --features no-table-memory-restrictions,slice16-memory-restrictions
+cargo test --features bytewise-mem-limit,slice16-mem-limit
+cargo test --features no-table-mem-limit,bytewise-mem-limit
+cargo test --features no-table-mem-limit,slice16-mem-limit
 
-cargo test --features no-table-memory-restrictions,bytewise-memory-restrictions,slice16-memory-restrictions
+cargo test --features no-table-mem-limit,bytewise-mem-limit,slice16-mem-limit
 

--- a/tests/test_under_all_feature_combinations.sh
+++ b/tests/test_under_all_feature_combinations.sh
@@ -3,13 +3,13 @@ set -ex
 cargo test
 cargo test --no-default-features
 
-cargo test --features slice16-defaults
-cargo test --features bytewise-defaults
-cargo test --features notable-defaults
+cargo test --features slice16-memory-restrictions
+cargo test --features bytewise-memory-restrictions
+cargo test --features no-table-memory-restrictions
 
-cargo test --features bytewise-defaults,slice16-defaults
-cargo test --features notable-defaults,bytewise-defaults
-cargo test --features notable-defaults,slice16-defaults
+cargo test --features bytewise-memory-restrictions,slice16-memory-restrictions
+cargo test --features no-table-memory-restrictions,bytewise-memory-restrictions
+cargo test --features no-table-memory-restrictions,slice16-memory-restrictions
 
-cargo test --features notable-defaults,bytewise-defaults,slice16-defaults
+cargo test --features no-table-memory-restrictions,bytewise-memory-restrictions,slice16-memory-restrictions
 

--- a/tests/test_under_all_feature_combinations.sh
+++ b/tests/test_under_all_feature_combinations.sh
@@ -1,0 +1,15 @@
+set -ex
+
+cargo test
+cargo test --no-default-features
+
+cargo test --features slice16-defaults
+cargo test --features bytewise-defaults
+cargo test --features notable-defaults
+
+cargo test --features bytewise-defaults,slice16-defaults
+cargo test --features notable-defaults,bytewise-defaults
+cargo test --features notable-defaults,slice16-defaults
+
+cargo test --features notable-defaults,bytewise-defaults,slice16-defaults
+


### PR DESCRIPTION
As a draft towards #93, and #92

This introduces three crate features which enable choosing the default implementations. The implementation is chosen based on the flag with the most hardware compatibility ( => the highest restrictions on memory usage)

    1. NoTable takes precedence over both others
    2. Bytewise takes precedence over Slice16 and is the default if no feature is selected
    3. Slice16 is used only if no other features are selected