### PR TITLE
fix readme regarding default impl selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ rust-version = "1.56"
 
 [features]
 # use the "NoTable" implementation for the default Crc<uXXX> struct, using no additional memory for a lookup table.
-# Takes predence over "bytewise-mem-limit" and "slice16-mem-limit"
+# Takes precedence over "bytewise-mem-limit" and "slice16-mem-limit"
 no-table-mem-limit = []
 # use the "Bytewise" implementation for the default Crc<uXXX> struct, using 256 entries of the respective width for a lookup table.
-# Takes predence over "slice16-mem-limit" and is used if no feature is selected
+# Takes precedence over "slice16-mem-limit" and is used if no feature is selected
 bytewise-mem-limit = []
 # use the "Slice16" implementation for the default Crc<uXXX> struct, using 256 * 16 entries of the respective width for a lookup table.
 # Can be overriden by setting "bytewise-mem-limit" and "slice16-mem-limit"

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ See the benchmark section for hints, but do benchmarks on your target hardware t
 2. `Bytewise` provides an implementation that uses a lookup table that uses 256 entries of the used width (e.g. for u32 thats 256 * 4 bytes)
 3. `Slice16` provides an implementation that uses a lookup table that uses 16 * 256 entries of the used width (e.g. for u32 thats 16 * 256 * 4 bytes)
 
-These can be used by substituting `Crc<uxxx>` with e.g. `Crc<Slice16<uxxx>>`. If you use `Crc<uxxx>` the default implementation is used which are as follows:
+These can be used by substituting `Crc<uxxx>` with e.g. `Crc<Slice16<uxxx>>`. The flavor for `Crc<uxxx>` is chosen based on three crate features:
 
-* u8 -> Slice16
-* u16 -> Slice16
-* u32 -> Slice16
-* u64 -> Slice16
-* u128 -> Bytewise
+* no-table-mem-limit: Takes precedence over "bytewise-mem-limit" and "slice16-mem-limit"
+* bytewise-mem-limit: Takes precedence over "slice16-mem-limit"
+* slice16-mem-limit: Can be overriden by setting "bytewise-mem-limit" and "slice16-mem-limit"
+
+If no feature is selected, the `Bytewise` flavor is used.
 
 Note that these tables can bloat your binary size if you precalculate them at compiletime (this happens in `Crc::new`). 
 Choosing a crate like oncecell or lazystatic to compute them once at runtime may be preferable where binary size is a concern.


### PR DESCRIPTION
Just noticed I forgot to update the readme according to the new selection of implementations via the crate features. Sorry about that!