### PR TITLE
Add cargo features for each CRC width

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,14 @@ categories = ["algorithms", "no-std"]
 edition = "2021"
 rust-version = "1.65"
 
+[features]
+default = ["crc8", "crc16", "crc32", "crc64", "crc128"]
+crc8 = []
+crc16 = []
+crc32 = []
+crc64 = []
+crc128 = []
+
 [dependencies]
 crc-catalog = "2.4.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,11 +31,21 @@
 pub use crc_catalog::algorithm::*;
 pub use crc_catalog::{Algorithm, Width};
 
-mod crc128;
-mod crc16;
-mod crc32;
-mod crc64;
+#[cfg(feature = "crc8")]
 mod crc8;
+
+#[cfg(feature = "crc16")]
+mod crc16;
+
+#[cfg(feature = "crc32")]
+mod crc32;
+
+#[cfg(feature = "crc64")]
+mod crc64;
+
+#[cfg(feature = "crc128")]
+mod crc128;
+
 mod table;
 mod util;
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,5 +1,6 @@
 use crate::util::*;
 
+#[cfg(feature = "crc8")]
 pub(crate) const fn crc8_table(width: u8, poly: u8, reflect: bool) -> [u8; 256] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
@@ -17,6 +18,7 @@ pub(crate) const fn crc8_table(width: u8, poly: u8, reflect: bool) -> [u8; 256] 
     table
 }
 
+#[cfg(feature = "crc8")]
 pub(crate) const fn crc8_table_slice_16(width: u8, poly: u8, reflect: bool) -> [[u8; 256]; 16] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
@@ -45,6 +47,7 @@ pub(crate) const fn crc8_table_slice_16(width: u8, poly: u8, reflect: bool) -> [
     table
 }
 
+#[cfg(feature = "crc16")]
 pub(crate) const fn crc16_table(width: u8, poly: u16, reflect: bool) -> [u16; 256] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
@@ -62,6 +65,7 @@ pub(crate) const fn crc16_table(width: u8, poly: u16, reflect: bool) -> [u16; 25
     table
 }
 
+#[cfg(feature = "crc16")]
 pub(crate) const fn crc16_table_slice_16(width: u8, poly: u16, reflect: bool) -> [[u16; 256]; 16] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
@@ -94,6 +98,7 @@ pub(crate) const fn crc16_table_slice_16(width: u8, poly: u16, reflect: bool) ->
     table
 }
 
+#[cfg(feature = "crc32")]
 pub(crate) const fn crc32_table(width: u8, poly: u32, reflect: bool) -> [u32; 256] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
@@ -112,6 +117,7 @@ pub(crate) const fn crc32_table(width: u8, poly: u32, reflect: bool) -> [u32; 25
     table
 }
 
+#[cfg(feature = "crc32")]
 pub(crate) const fn crc32_table_slice_16(width: u8, poly: u32, reflect: bool) -> [[u32; 256]; 16] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
@@ -144,6 +150,7 @@ pub(crate) const fn crc32_table_slice_16(width: u8, poly: u32, reflect: bool) ->
     table
 }
 
+#[cfg(feature = "crc64")]
 pub(crate) const fn crc64_table(width: u8, poly: u64, reflect: bool) -> [u64; 256] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
@@ -161,6 +168,7 @@ pub(crate) const fn crc64_table(width: u8, poly: u64, reflect: bool) -> [u64; 25
     table
 }
 
+#[cfg(feature = "crc64")]
 pub(crate) const fn crc64_table_slice_16(width: u8, poly: u64, reflect: bool) -> [[u64; 256]; 16] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
@@ -193,6 +201,7 @@ pub(crate) const fn crc64_table_slice_16(width: u8, poly: u64, reflect: bool) ->
     table
 }
 
+#[cfg(feature = "crc128")]
 pub(crate) const fn crc128_table(width: u8, poly: u128, reflect: bool) -> [u128; 256] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
@@ -210,6 +219,7 @@ pub(crate) const fn crc128_table(width: u8, poly: u128, reflect: bool) -> [u128;
     table
 }
 
+#[cfg(feature = "crc128")]
 pub(crate) const fn crc128_table_slice_16(
     width: u8,
     poly: u128,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "crc8")]
 pub(crate) const fn crc8(poly: u8, reflect: bool, mut value: u8) -> u8 {
     let mut i = 0;
     if reflect {
@@ -14,6 +15,7 @@ pub(crate) const fn crc8(poly: u8, reflect: bool, mut value: u8) -> u8 {
     value
 }
 
+#[cfg(feature = "crc16")]
 pub(crate) const fn crc16(poly: u16, reflect: bool, mut value: u16) -> u16 {
     if reflect {
         let mut i = 0;
@@ -33,6 +35,7 @@ pub(crate) const fn crc16(poly: u16, reflect: bool, mut value: u16) -> u16 {
     value
 }
 
+#[cfg(feature = "crc32")]
 pub(crate) const fn crc32(poly: u32, reflect: bool, mut value: u32) -> u32 {
     if reflect {
         let mut i = 0;
@@ -52,6 +55,7 @@ pub(crate) const fn crc32(poly: u32, reflect: bool, mut value: u32) -> u32 {
     value
 }
 
+#[cfg(feature = "crc64")]
 pub(crate) const fn crc64(poly: u64, reflect: bool, mut value: u64) -> u64 {
     if reflect {
         let mut i = 0;
@@ -71,6 +75,7 @@ pub(crate) const fn crc64(poly: u64, reflect: bool, mut value: u64) -> u64 {
     value
 }
 
+#[cfg(feature = "crc128")]
 pub(crate) const fn crc128(poly: u128, reflect: bool, mut value: u128) -> u128 {
     if reflect {
         let mut i = 0;


### PR DESCRIPTION
Motivation: on AVR compiling the library gives the following error:

> error: values of the type `[[u128; 256]; 16]` are too big for the target architecture