### PR TITLE
CRC128 und CRC64 are feature-gated now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ rust-version = "1.65"
 [dependencies]
 crc-catalog = "2.4.0"
 
+[features]
+default = ["crc128", "crc64"]
+crc128 = []
+crc64 = []
+
 [dev-dependencies]
 criterion = { version = "0.4" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,11 @@
 pub use crc_catalog::algorithm::*;
 pub use crc_catalog::{Algorithm, Width};
 
+#[cfg(feature = "crc128")]
 mod crc128;
 mod crc16;
 mod crc32;
+#[cfg(feature = "crc64")]
 mod crc64;
 mod crc8;
 mod table;

--- a/src/table.rs
+++ b/src/table.rs
@@ -144,6 +144,7 @@ pub(crate) const fn crc32_table_slice_16(width: u8, poly: u32, reflect: bool) ->
     table
 }
 
+#[cfg(feature = "crc64")]
 pub(crate) const fn crc64_table(width: u8, poly: u64, reflect: bool) -> [u64; 256] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
@@ -161,6 +162,7 @@ pub(crate) const fn crc64_table(width: u8, poly: u64, reflect: bool) -> [u64; 25
     table
 }
 
+#[cfg(feature = "crc64")]
 pub(crate) const fn crc64_table_slice_16(width: u8, poly: u64, reflect: bool) -> [[u64; 256]; 16] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
@@ -193,6 +195,7 @@ pub(crate) const fn crc64_table_slice_16(width: u8, poly: u64, reflect: bool) ->
     table
 }
 
+#[cfg(feature = "crc128")]
 pub(crate) const fn crc128_table(width: u8, poly: u128, reflect: bool) -> [u128; 256] {
     let poly = if reflect {
         let poly = poly.reverse_bits();
@@ -210,6 +213,7 @@ pub(crate) const fn crc128_table(width: u8, poly: u128, reflect: bool) -> [u128;
     table
 }
 
+#[cfg(feature = "crc128")]
 pub(crate) const fn crc128_table_slice_16(
     width: u8,
     poly: u128,

--- a/src/util.rs
+++ b/src/util.rs
@@ -52,6 +52,7 @@ pub(crate) const fn crc32(poly: u32, reflect: bool, mut value: u32) -> u32 {
     value
 }
 
+#[cfg(feature = "crc64")]
 pub(crate) const fn crc64(poly: u64, reflect: bool, mut value: u64) -> u64 {
     if reflect {
         let mut i = 0;
@@ -71,6 +72,7 @@ pub(crate) const fn crc64(poly: u64, reflect: bool, mut value: u64) -> u64 {
     value
 }
 
+#[cfg(feature = "crc128")]
 pub(crate) const fn crc128(poly: u128, reflect: bool, mut value: u128) -> u128 {
     if reflect {
         let mut i = 0;


### PR DESCRIPTION
Fixes #122  . I think it might be okay for this to be a minor change: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-add ? The features are default features, so nothing should break for users.