### PR TITLE
Implement `DigestOps` trait for `Digest` across CRC types.

### DIFF
--- a/src/crc128.rs
+++ b/src/crc128.rs
@@ -51,11 +51,22 @@ where
         Digest { crc, value }
     }
 
-    pub const fn update(&mut self, bytes: &[u8]) {
+    pub const fn finalize(self) -> u128 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}
+
+impl<'a, const L: usize> DigestOps for Digest<'a, u128, Table<L>>
+where
+    Table<L>: private::Sealed,
+{
+    type Width = u128;
+
+    fn update(&mut self, bytes: &[u8]) {
         self.value = self.crc.update(self.value, bytes);
     }
 
-    pub const fn finalize(self) -> u128 {
+    fn finalize(self) -> Self::Width {
         finalize(self.crc.algorithm, self.value)
     }
 }

--- a/src/crc16.rs
+++ b/src/crc16.rs
@@ -51,11 +51,22 @@ where
         Digest { crc, value }
     }
 
-    pub const fn update(&mut self, bytes: &[u8]) {
+    pub const fn finalize(self) -> u16 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}
+
+impl<'a, const L: usize> DigestOps for Digest<'a, u16, Table<L>>
+where
+    Table<L>: private::Sealed,
+{
+    type Width = u16;
+
+    fn update(&mut self, bytes: &[u8]) {
         self.value = self.crc.update(self.value, bytes);
     }
 
-    pub const fn finalize(self) -> u16 {
+    fn finalize(self) -> Self::Width {
         finalize(self.crc.algorithm, self.value)
     }
 }

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -51,11 +51,22 @@ where
         Digest { crc, value }
     }
 
-    pub const fn update(&mut self, bytes: &[u8]) {
+    pub const fn finalize(self) -> u32 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}
+
+impl<'a, const L: usize> DigestOps for Digest<'a, u32, Table<L>>
+where
+    Table<L>: private::Sealed,
+{
+    type Width = u32;
+
+    fn update(&mut self, bytes: &[u8]) {
         self.value = self.crc.update(self.value, bytes);
     }
 
-    pub const fn finalize(self) -> u32 {
+    fn finalize(self) -> Self::Width {
         finalize(self.crc.algorithm, self.value)
     }
 }

--- a/src/crc64.rs
+++ b/src/crc64.rs
@@ -51,11 +51,22 @@ where
         Digest { crc, value }
     }
 
-    pub const fn update(&mut self, bytes: &[u8]) {
+    pub const fn finalize(self) -> u64 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}
+
+impl<'a, const L: usize> DigestOps for Digest<'a, u64, Table<L>>
+where
+    Table<L>: private::Sealed,
+{
+    type Width = u64;
+
+    fn update(&mut self, bytes: &[u8]) {
         self.value = self.crc.update(self.value, bytes);
     }
 
-    pub const fn finalize(self) -> u64 {
+    fn finalize(self) -> Self::Width {
         finalize(self.crc.algorithm, self.value)
     }
 }

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -51,11 +51,22 @@ where
         Digest { crc, value }
     }
 
-    pub const fn update(&mut self, bytes: &[u8]) {
+    pub const fn finalize(self) -> u8 {
+        finalize(self.crc.algorithm, self.value)
+    }
+}
+
+impl<'a, const L: usize> DigestOps for Digest<'a, u8, Table<L>>
+where
+    Table<L>: private::Sealed,
+{
+    type Width = u8;
+
+    fn update(&mut self, bytes: &[u8]) {
         self.value = self.crc.update(self.value, bytes);
     }
 
-    pub const fn finalize(self) -> u8 {
+    fn finalize(self) -> Self::Width {
         finalize(self.crc.algorithm, self.value)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@
 //!
 //! Using a custom algorithm:
 //! ```rust
+//! use crc::DigestOps;
+//!
 //! const CUSTOM_ALG: crc::Algorithm<u16> = crc::Algorithm {
 //!     width: 16,
 //!     poly: 0x8005,
@@ -77,6 +79,13 @@ pub struct Crc<W: Width, I: Implementation = DefaultImpl> {
 pub struct Digest<'a, W: Width, I: Implementation = DefaultImpl> {
     crc: &'a Crc<W, I>,
     value: W,
+}
+
+pub trait DigestOps {
+    type Width: Width;
+
+    fn update(&mut self, bytes: &[u8]);
+    fn finalize(self) -> Self::Width;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pr adds the `DigestOps` trait which is implemented by all Digest types. It allows to use `update` and `finalize` of any `Digest` without the Implementation (Table) constraint.

This is useful for cases where code does not care about the Implementation (Table) of a digest, like a checksum function on a struct which generates a checksum for it.

Before this trait I had to use this to be able to accept digests with (almost) any table type:
```rust
use crc::NoTable;

pub enum Digest<'a, W: crc::Width> {
    NoTable(crc::Digest<'a, W, NoTable>),
    Table(crc::Digest<'a, W>)
}

impl Digest<'_, u32> {
    pub fn update(&mut self, bytes: &[u8]) {
        match self {
            Digest::NoTable(digest) => {
                digest.update(bytes)
            }
            Digest::Table(digest) => {
                digest.update(bytes)
            }
        }
    }
    
    pub fn finalize(self) -> u32 {
        match self {
            Digest::NoTable(digest) => {
                digest.finalize()
            }
            Digest::Table(digest) => {
                digest.finalize()
            }
        }
    }
}
```


Here is an example how this can be done better with tools in the library itself, the DigestOps trait. The Width is still relevant but the implementation detail of Implementation (Table) is gone, as it is not relevant.
```rust
use crc::NoTable;

pub struct SomeStruct {
    x: u32,
    buffer: [u8; 64],
    y: bool,
}

impl SomeStruct {
    pub fn checksum(&self, mut digest: impl crc::DigestOps<Width = u32>) -> u32 {
        digest.update(&self.x.to_le_bytes());
        digest.update(&self.buffer);

        let y_byte: u8 = if self.y { 1 } else { 0 };
        digest.update(&[y_byte]);

        digest.finalize()
    }
}

fn main() {
    let my_struct = SomeStruct {
        x: 42,
        buffer: [0; 64],
        y: true,
    };

    let crc32 = crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
    let checksum = my_struct.checksum(crc32.digest());

    let crc32_no_table = crc::Crc::<u32, NoTable>::new(&crc::CRC_32_ISO_HDLC);
    let checksum_no_table = my_struct.checksum(crc32_no_table.digest());
}
```

The `finalize` function is duplicated as the trait function cannot be of type `const fn` and to keep backward compatibility I kept it.