### PR TITLE
impl Debug for Digest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@
 #![no_std]
 #![forbid(unsafe_code)]
 
+use core::fmt::Debug;
+
 pub use crc_catalog::algorithm::*;
 pub use crc_catalog::{Algorithm, Width};
 
@@ -77,6 +79,14 @@ pub struct Crc<W: Width, I: Implementation = DefaultImpl> {
 pub struct Digest<'a, W: Width, I: Implementation = DefaultImpl> {
     crc: &'a Crc<W, I>,
     value: W,
+}
+
+impl<'a, W: Width + Debug, I: Implementation> Debug for Digest<'a, W, I> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Digest")
+            .field("value", &self.value)
+            .finish()
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,10 @@ pub struct Digest<'a, W: Width, I: Implementation = DefaultImpl> {
 
 impl<'a, W: Width + Debug, I: Implementation> Debug for Digest<'a, W, I> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let width = "0x".len() + size_of::<W>() * 2 as usize;
+        let value = &self.value;
         f.debug_struct("Digest")
-            .field("value", &self.value)
+            .field("value", &format_args!("{value:#0width$x?}"))
             .finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub struct Digest<'a, W: Width, I: Implementation = DefaultImpl> {
     value: W,
 }
 
-impl<'a, W: Width + Debug, I: Implementation> Debug for Digest<'a, W, I> {
+impl<W: Width + Debug, I: Implementation> Debug for Digest<'_, W, I> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let width = "0x".len() + size_of::<W>() * 2 as usize;
         let value = &self.value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ pub struct Digest<'a, W: Width, I: Implementation = DefaultImpl> {
 
 impl<W: Width + Debug, I: Implementation> Debug for Digest<'_, W, I> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let width = "0x".len() + size_of::<W>() * 2 as usize;
+        let width = "0x".len() + size_of::<W>() * 2;
         let value = &self.value;
         f.debug_struct("Digest")
             .field("value", &format_args!("{value:#0width$x?}"))


### PR DESCRIPTION
Closes #129 

This implementation only shows the `value` field and not the info about the CRC. We could technically show the CRC config, but I don't think it would be that useful.